### PR TITLE
fix(specfixtures): align hive test-driver fixture decoding with devnet5 schema

### DIFF
--- a/internal/api/testdriver/transition.go
+++ b/internal/api/testdriver/transition.go
@@ -25,7 +25,7 @@ func StateTransitionHandler() http.HandlerFunc {
 		}
 
 		if len(fixture.Blocks) == 0 {
-			if fixture.ExpectException != "" {
+			if fixture.ExpectedException() != "" {
 				if err := statetransition.ProcessSlots(state, state.Slot); err != nil {
 					writeStateTransitionFailure(w, err.Error())
 					return

--- a/internal/specfixtures/parse_test.go
+++ b/internal/specfixtures/parse_test.go
@@ -1,6 +1,7 @@
 package specfixtures
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"strings"
@@ -191,5 +192,45 @@ func TestTestValidatorMapsCanonicalPublicKeyFields(t *testing.T) {
 	}
 	if v.Index != 7 {
 		t.Fatalf("index not mapped: got %d", v.Index)
+	}
+}
+
+func TestFixtureSignedBlockMapsNestedProof(t *testing.T) {
+	const raw = `{
+		"block": {"slot": 1, "proposerIndex": 1, "parentRoot": "0x01", "stateRoot": "0x02", "body": {"attestations": {"data": []}}},
+		"proof": {"proof": {"data": "0x0102"}}
+	}`
+	var sb FixtureSignedBlock
+	if err := json.Unmarshal([]byte(raw), &sb); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	signed, err := sb.ToSignedBlock()
+	if err != nil {
+		t.Fatalf("ToSignedBlock: %v", err)
+	}
+	if want := []byte{0x01, 0x02}; !bytes.Equal(signed.Proof.Proof, want) {
+		t.Fatalf("proof = %x, want %x — nested proof.proof.data not mapped", signed.Proof.Proof, want)
+	}
+}
+
+func TestStateTransitionFixtureRejectionMarkerSpellings(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"rejectionReason", `{"rejectionReason":"EMPTY_VALIDATOR_REGISTRY"}`, "EMPTY_VALIDATOR_REGISTRY"},
+		{"expectException", `{"expectException":"SOME_ERROR"}`, "SOME_ERROR"},
+		{"expectExceptionWins", `{"expectException":"A","rejectionReason":"B"}`, "A"},
+		{"absent", `{}`, ""},
+	}
+	for _, tc := range cases {
+		var f StateTransitionFixture
+		if err := json.Unmarshal([]byte(tc.raw), &f); err != nil {
+			t.Fatalf("%s: unmarshal: %v", tc.name, err)
+		}
+		if got := f.ExpectedException(); got != tc.want {
+			t.Fatalf("%s: ExpectedException() = %q, want %q", tc.name, got, tc.want)
+		}
 	}
 }

--- a/internal/specfixtures/signature.go
+++ b/internal/specfixtures/signature.go
@@ -15,7 +15,7 @@ func (sb *FixtureSignedBlock) ToSignedBlock() (*types.SignedBlock, error) {
 		return nil, fmt.Errorf("signedBlock.block: %w", err)
 	}
 
-	proof, err := ParseHexBytes(sb.Proof.Data)
+	proof, err := ParseHexBytes(sb.Proof.Proof.Data)
 	if err != nil {
 		return nil, fmt.Errorf("signedBlock.proof.proof: %w", err)
 	}

--- a/internal/specfixtures/types.go
+++ b/internal/specfixtures/types.go
@@ -10,6 +10,14 @@ type StateTransitionFixture struct {
 	Post                   *TestPostState `json:"post"`
 	ExpectException        string         `json:"expectException"`
 	ExpectExceptionMessage string         `json:"expectExceptionMessage"`
+	RejectionReason        string         `json:"rejectionReason"`
+}
+
+func (f *StateTransitionFixture) ExpectedException() string {
+	if f.ExpectException != "" {
+		return f.ExpectException
+	}
+	return f.RejectionReason
 }
 
 type TestState struct {

--- a/internal/specfixtures/types.go
+++ b/internal/specfixtures/types.go
@@ -175,6 +175,10 @@ type VerifySignaturesFixture struct {
 }
 
 type FixtureSignedBlock struct {
-	Block TestBlock   `json:"block"`
+	Block TestBlock         `json:"block"`
+	Proof FixtureBlockProof `json:"proof"`
+}
+
+type FixtureBlockProof struct {
 	Proof FCProofData `json:"proof"`
 }


### PR DESCRIPTION
## Problem

With the test-driver routes now compiled into the devnet5 image, the hive lean
spec suites exposed two remaining fixture-schema drifts in `internal/specfixtures`:

1. **Signed-block proof nesting** — fixtures serialize the block proof as
   `signedBlock.proof.proof.data` (mirroring the `MultiMessageAggregate`
   wrapper); gean decoded the flat `signedBlock.proof.data`. The proof came out
   empty, failing `verify_signatures/test_valid_signatures` with
   `"block proof missing"` — and letting both structural-rejection vectors pass
   for the wrong reason (decode artifact instead of real XMSS verification).

2. **Rejection marker spelling** — newer leanSpec fixtures use
   `rejectionReason`, gean only mapped the older `expectException`. The hive
   simulator accepts either. On empty-blocks fixtures the unset marker skipped
   the deterministic failure probe, so
   `state_transition/test_empty_validator_registry` reported success where the
   fixture demands rejection.

Both are the same failure mode as the earlier `attestationPublicKey` drift:
`encoding/json` ignores shape mismatches, so the bug ships silently and only
surfaces in a hive run.

## Fix

- `FixtureSignedBlock.Proof` now models the nested wrapper (`FixtureBlockProof`),
  matching how `FCProof` already handles the attestation path.
- `StateTransitionFixture` gains `RejectionReason` and an `ExpectedException()`
  accessor honoring both spellings (`expectException` wins, matching the
  simulator's precedence in `spec_assets.rs`).
- Regression tests pin both wire shapes in `parse_test.go`.

## Verification

Local hive run against this build (all three lean spec suites, gean only):

| Suite | Result |
|---|---|
| lean-spec-tests-fork-choice | 124/124 |
| lean-spec-tests-state-transition | 75/75 |
| lean-spec-tests-verify-signatures | 4/4 |