### PR TITLE
perf(block-import): fat-LTO, state-HTR scale benchmark, and marooned-fork backfill

### DIFF
--- a/.github/workflows/pr-issue-check.yml
+++ b/.github/workflows/pr-issue-check.yml
@@ -19,12 +19,12 @@ jobs:
   check-issue:
     if: false
     # original condition: >-
-      github.event_name == 'pull_request' ||
-      (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        contains(github.event.comment.body, '/recheck-issue-link')
-      )
+    #   github.event_name == 'pull_request' ||
+    #   (
+    #     github.event_name == 'issue_comment' &&
+    #     github.event.issue.pull_request &&
+    #     contains(github.event.comment.body, '/recheck-issue-link')
+    #   )
     runs-on: ubuntu-latest
     steps:
       - name: Check for linked issue

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ test: ## Run unit tests (excludes crypto FFI and spec tests)
 test-ffi: ffi ## Run XMSS crypto FFI tests (builds FFI first)
 	go test ./xmss/ -v -count=1
 
-test-spec: leanSpec/fixtures/.generated-$(LEAN_SPEC_COMMIT_HASH) ## Run spec fixture tests only (fast, excludes xmss FFI)
+test-spec: ffi leanSpec/fixtures/.generated-$(LEAN_SPEC_COMMIT_HASH) ## Run spec fixture tests only (fast, excludes xmss FFI)
 	go test ./internal/spectests/  -count=1 -tags=spectests
 
-test-all: leanSpec/fixtures/.generated-$(LEAN_SPEC_COMMIT_HASH) ## Run all tests including spec fixtures and xmss FFI (slow)
+test-all: ffi leanSpec/fixtures/.generated-$(LEAN_SPEC_COMMIT_HASH) ## Run all tests including spec fixtures and xmss FFI (slow)
 	go test ./... -v -count=1 -tags=spectests
 
 lint: ## Run linters for go & rust

--- a/docs/aggregator-stability.md
+++ b/docs/aggregator-stability.md
@@ -100,16 +100,15 @@ exceeding the session budget. Levers, in risk order:
 1. Skip already-justified targets (DONE). process_attestations ignores a vote
    once its target is justified, so proving it wastes budget. Filtered in
    `orderedGroups` via `IsSlotJustified`. Safe, frees budget for open targets.
-2. Parallel group proving — INVESTIGATED, NOT safe to ship blind. The proving
-   gate is capacity-1 (single-flight by design) and the FFI has no per-call
-   guard; safety today relies entirely on the gate. rayon is pulled by the
-   signature lib, not the STARK aggregation crates, so the prover's threading and
-   concurrency-safety are unconfirmed, and STARK proofs use large scratch memory
-   (concurrent proofs multiply peak memory). After a recent FFI segfault, adding
-   concurrent prover calls needs, first: WS-6 (handle ownership), a concurrency
-   stress test proving `xmss_aggregate_type_1` is reentrant, a memory-per-proof
-   measurement to bound the degree, and a benchmark showing a real gain. Only
-   then, bounded parallelism.
+2. Parallel group proving — MEASURED, DROPPED. The FFI concurrency stress test
+   (xmss/concurrency_stress_test.go) proved it reentrant with independent handles
+   (4 concurrent proofs, all valid, no crash) but showed **no throughput gain**:
+   speedup 1.09x (serial 216ms/proof vs parallel 198ms/proof), because the STARK
+   prover already saturates all cores per proof. It also added ~95MB RSS per
+   concurrent proof on a ~1.3GB baseline. So concurrency only oversubscribes cores
+   and multiplies memory — pure downside. The per-proof time is core-optimal
+   already; throughput improves only by needing fewer proofs (skip-justified,
+   frontier-first) or a faster prover upstream, not by parallelizing.
 
 ### WS-3 — Aggregator recovery / catch-up (safety net)
 Files: `internal/syncer/`, `internal/node/`.

--- a/docs/aggregator-stability.md
+++ b/docs/aggregator-stability.md
@@ -85,17 +85,31 @@ rate, finality lag (head − finalized), backlog size, behind-slots, prover
 wait/unavailable rate. Warn when finality lag or session duration trends up —
 this run gave ~3K slots (11K→14K) of warning that nothing surfaced.
 
-### WS-1 — Cached / incremental state HTR (headroom; consensus-critical)
-Files: `internal/types/` (State HTR path), new cache type; gated by
-`internal/statetransition/state_scale_bench_test.go` + spec fixtures.
+### WS-1 — Cached / incremental state HTR — DROPPED (measured, not the bottleneck)
+Benchmarked `State.HashTreeRoot` (state_scale_bench_test.go): ~2ms at 21K slots
+(v64 and v512), ~8.5ms at 100K — on par with ethlambda's measured state
+transition (62µs→2.2ms). It is <1% of the XMSS cost (aggregation proof 150–340ms,
+import verify ~30–50ms). Caching would save ~2ms for a consensus-critical,
+chain-split-risk change. Not worth it; the throughput bottleneck is XMSS, not
+Merkle hashing. Revisit only past ~100K slots.
 
-Cache the merkle subtrees of the append-only List/bitlist fields and, on append,
-recompute only the O(log n) path plus the length mixin, instead of re-merkleizing
-the whole list. Reduces per-proof and import cost so the loop starts later and
-gean sustains far higher slots — but it is headroom, not the loop fix. Hard
-requirement: cached root MUST equal the full fastssz root for every state
-(property test over random + fixture states + full spec fixtures). Roll out one
-field at a time (start `HistoricalBlockHashes`) behind an equivalence test.
+### WS-7 — Aggregation proving throughput (the real throughput lever)
+The finality lag came from XMSS proving: group count × per-proof (~200ms)
+exceeding the session budget. Levers, in risk order:
+
+1. Skip already-justified targets (DONE). process_attestations ignores a vote
+   once its target is justified, so proving it wastes budget. Filtered in
+   `orderedGroups` via `IsSlotJustified`. Safe, frees budget for open targets.
+2. Parallel group proving — INVESTIGATED, NOT safe to ship blind. The proving
+   gate is capacity-1 (single-flight by design) and the FFI has no per-call
+   guard; safety today relies entirely on the gate. rayon is pulled by the
+   signature lib, not the STARK aggregation crates, so the prover's threading and
+   concurrency-safety are unconfirmed, and STARK proofs use large scratch memory
+   (concurrent proofs multiply peak memory). After a recent FFI segfault, adding
+   concurrent prover calls needs, first: WS-6 (handle ownership), a concurrency
+   stress test proving `xmss_aggregate_type_1` is reentrant, a memory-per-proof
+   measurement to bound the degree, and a benchmark showing a real gain. Only
+   then, bounded parallelism.
 
 ### WS-3 — Aggregator recovery / catch-up (safety net)
 Files: `internal/syncer/`, `internal/node/`.

--- a/docs/aggregator-stability.md
+++ b/docs/aggregator-stability.md
@@ -51,10 +51,21 @@ Two parts:
    release the prover) when the estimated session-so-far + next proof would
    exceed the deadline, instead of overrunning. Converts the cliff into graceful
    degradation — gean stays synced.
-2. **Order groups finality-first** so the budget is spent on the aggregates that
-   let finality advance (freshest justifiable target / head-descendant roots),
-   not on stale-view or old backlog roots. This lets finality progress even under
-   backlog, which drains the loop instead of feeding it.
+2. **Order groups finality-first.** Verified against leanSpec eca701e
+   (process_attestations): a source finalizes only when the checkpoint
+   immediately after it is justified — no justifiable slot between source and
+   target — so finalization advances one checkpoint at a time from the frontier.
+   Newest-first spends the budget on the highest target (advancing head /
+   justification) and leaves the frontier-adjacent target unaggregated, so
+   finalization stalls while the head moves — the observed stall shape. Ordering
+   is a local heuristic, not spec-mandated, so reordering is spec-safe.
+
+Status: both parts implemented (hard bound + frontier-first ordering = ascending
+target slot). Group order is the only change; every aggregate produced is
+spec-valid. The head-vs-finality tension and the sparse justifiable-slot
+structure make the exact benefit structure-dependent, so a devnet run (truncating
+aggregator finalizes under frontier-first, stalls under newest-first) is the
+remaining validation before merge.
 
 No consensus-root change; aggregates produced remain spec-valid.
 

--- a/docs/aggregator-stability.md
+++ b/docs/aggregator-stability.md
@@ -1,0 +1,111 @@
+# Aggregator stability at scale — engineering plan
+
+Tracks issue #398. Goal: make gean sustain the aggregator seat indefinitely at
+scale, degrade gracefully if it ever falls behind, and recover on its own —
+matching then bettering ethlambda's stability.
+
+Evidence: a ~31h run (gean aggregator + ethlambda + lantern) had gean's head
+freeze at slot 14,349. Aggregation proof time grew with state (first budget hit
+slot 10,101; 1.6–3.0s per session by 14K; 461 truncations), a single proof
+exceeded the whole 1600ms budget, block import starved on the shared prover, and
+gean fell off the chain irrecoverably — stalling network finality at 14,311.
+ethlambda stayed at ~30–70ms import with state transition 62µs→2.2ms across 14K
+slots (cached hashing), and never bore the every-slot aggregator load.
+
+## Root cause (code-level) — corrected after log re-analysis
+
+The dominant driver is a **finality-lag / aggregation-backlog positive feedback
+loop**, not state-HTR growth. Measured on the stalled run:
+
+- per-proof XMSS cost grew only ~2x over the run (~160ms → ~250–340ms).
+- what blows the 1600ms budget is **group count per session** — the number of
+  distinct attestation data roots the session must prove — which rose from 1–2
+  to 6+ (session totals 350ms → 2055ms). It is noisy: some sessions still fit.
+- finality lag (head − finalized) held ~10 until ~slot 11–12K, then jumped to
+  ~98, and the pending-signature backlog grew in step (2–3 → 19+ roots).
+
+The loop: a session first exceeds budget (modest per-proof creep × a few groups)
+→ `aggregateFromSnapshot` truncates → incomplete vote coverage → finality lags →
+`AttestationSignatureMap` (pruned only below finalized) accumulates roots across
+the now-wider unfinalized window → next session has more groups → exceeds budget
+harder → runaway. Eventually the session runs long enough (2–3s) to starve block
+import on the shared prover, and gean falls off the chain. Stale-view
+attestations from a lagging peer (lantern, behind from ~9,447) plausibly inflate
+the distinct-root count and feed the loop.
+
+State-HTR growth (`State.HashTreeRoot`, fastssz, re-merkleizes the append-only
+`HistoricalBlockHashes` / bitlists every call) is real but **secondary here** —
+it only reduces headroom (the ~2x per-proof creep, block import 34→56ms). It
+becomes dominant only at much larger scale. So caching helps but does **not**
+break the loop.
+
+## Workstreams (corrected priority)
+
+### WS-2 — Break the feedback loop: hard session bound + finality-first ordering (PRIMARY)
+File: `internal/aggregation/aggregate.go`, `worker.go`, `orderedGroups`.
+
+Two parts:
+1. **Hard-bound the session** so it can never run long enough to starve import:
+   `maxUnitsWithin` floors at 2 and models only per-unit cost, so the worker
+   always starts even when it cannot finish. Skip a group (mark truncated,
+   release the prover) when the estimated session-so-far + next proof would
+   exceed the deadline, instead of overrunning. Converts the cliff into graceful
+   degradation — gean stays synced.
+2. **Order groups finality-first** so the budget is spent on the aggregates that
+   let finality advance (freshest justifiable target / head-descendant roots),
+   not on stale-view or old backlog roots. This lets finality progress even under
+   backlog, which drains the loop instead of feeding it.
+
+No consensus-root change; aggregates produced remain spec-valid.
+
+### WS-5 — Bound the backlog independent of finality (PRIMARY)
+File: `internal/store/gossip.go` (`AttestationSignatureMap`), pruning.
+
+Signatures are pruned only below finalized, so a stalled finality lets the
+backlog grow unbounded — the fuel for the loop. Cap the pending window (e.g.
+drop/ignore roots older than a bounded lookback from head, or above a size cap),
+so group count per session is bounded regardless of finality state.
+
+### WS-4 — Guardrails & early warning (safe; pair with the above)
+File: `internal/metrics/`, aggregation worker, `internal/node/tick.go` status.
+
+Emit/observe: session duration vs budget, group count per session, budget-hit
+rate, finality lag (head − finalized), backlog size, behind-slots, prover
+wait/unavailable rate. Warn when finality lag or session duration trends up —
+this run gave ~3K slots (11K→14K) of warning that nothing surfaced.
+
+### WS-1 — Cached / incremental state HTR (headroom; consensus-critical)
+Files: `internal/types/` (State HTR path), new cache type; gated by
+`internal/statetransition/state_scale_bench_test.go` + spec fixtures.
+
+Cache the merkle subtrees of the append-only List/bitlist fields and, on append,
+recompute only the O(log n) path plus the length mixin, instead of re-merkleizing
+the whole list. Reduces per-proof and import cost so the loop starts later and
+gean sustains far higher slots — but it is headroom, not the loop fix. Hard
+requirement: cached root MUST equal the full fastssz root for every state
+(property test over random + fixture states + full spec fixtures). Roll out one
+field at a time (start `HistoricalBlockHashes`) behind an equivalence test.
+
+### WS-3 — Aggregator recovery / catch-up (safety net)
+Files: `internal/syncer/`, `internal/node/`.
+
+Ensure a lagging aggregator can rejoin: batch/parallel XMSS verification during
+backfill so catch-up rate > 1 block / 4s; checkpoint resync when lag exceeds a
+threshold; confirm the duty gate stands the node down while lagging (correct) but
+that recovery is actually reachable (the gap this run exposed).
+
+## Acceptance criteria
+
+- Multi-machine long run, gean as aggregator with real attestation load, sustains
+  past ~30K slots: zero budget-hit truncations, aggregation proof < 1s.
+- State HTR / block-build cost flat (not slot-dependent) on the scale benchmark.
+- An aggregator forced N slots behind recovers to head on its own.
+- If the ceiling is ever hit, finality lags but the node stays synced (graceful),
+  never the cliff.
+
+## Notes
+
+- Early aggregation (#396/#397) delays but does not remove this ceiling, and may
+  worsen the failure mode (front-loads prover contention vs import). Settle with a
+  controlled A/B (early-agg ON vs OFF, identical hardware + client mix + validators).
+- lantern was a straggler this run (fell behind ~9,447); out of scope here.

--- a/docs/aggregator-stability.md
+++ b/docs/aggregator-stability.md
@@ -69,13 +69,31 @@ remaining validation before merge.
 
 No consensus-root change; aggregates produced remain spec-valid.
 
-### WS-5 — Bound the backlog independent of finality (PRIMARY)
-File: `internal/store/gossip.go` (`AttestationSignatureMap`), pruning.
+### WS-5 — Bound the backlog behind head — TRIED AND REVERTED
+A head-relative signature prune (drop roots more than 512 slots behind head) was
+implemented and merged, then reverted after a server run exposed two failures:
 
-Signatures are pruned only below finalized, so a stalled finality lets the
-backlog grow unbounded — the fuel for the loop. Cap the pending window (e.g.
-drop/ignore roots older than a bounded lookback from head, or above a size cap),
-so group count per session is bounded regardless of finality state.
+1. It deleted the finalization-frontier votes. Once finality lag exceeded the
+   window, the votes needed to finalize the next checkpoint sat below head minus
+   the window and were pruned, so finalization froze (12,880 while head ran to
+   14,355). Any head-relative cap has this flaw: everything between finalized and
+   head is potentially finality-critical, so it cannot be safely dropped.
+2. It caused a use-after-free crash. The prune runs on the tick loop and frees
+   XMSS signature handles; the aggregation worker runs async on a snapshot that
+   shares those handle pointers. Pruning the frontier — exactly the votes the
+   frontier-first worker aggregates — freed handles the worker was still using,
+   segfaulting inside the aggregate FFI at ~16h.
+
+Lesson: the backlog is drained by advancing finality (frontier-first + WS-1
+throughput), not by pruning above finalized. A genuine long-stall memory bound
+belongs with WS-3 recovery (checkpoint resync), and the snapshot must not share
+freeable handles with the live map (see WS-6).
+
+### WS-6 — Snapshot handle lifetime (new; correctness)
+The aggregation snapshot copies signature entries but shares the raw XMSS handle
+pointers with the live map, and any prune frees them. Frontier-first widened the
+overlap enough to crash. Make snapshots own their handles (re-parse from bytes in
+the worker, or ref-count) so no prune can free a handle a live session holds.
 
 ### WS-4 — Guardrails & early warning (safe; pair with the above)
 File: `internal/metrics/`, aggregation worker, `internal/node/tick.go` status.

--- a/docs/block-import-perf.md
+++ b/docs/block-import-perf.md
@@ -1,0 +1,77 @@
+# Block-import performance at scale
+
+Branch: `perf/block-import-at-scale`
+
+Tracks the 512-validator devnet degradation: block-import time, CPU, time-to-
+finality and reorg count all climb as the chain lengthens (observed past ~21k
+slots); the 64-node devnet is fine only because it has more CPU headroom.
+
+## Root cause (measured)
+
+Block import verifies the post-state via `VerifyStateRoot`, which calls
+`state.HashTreeRoot()` — a full re-merkleization of the entire state on **every**
+imported block. The state's per-slot history arrays (`historical_block_hashes`,
+`justified_slots`) grow one entry per slot, so that cost grows with chain length.
+
+`internal/statetransition/state_scale_bench_test.go` isolates it (pure Go, no FFI):
+
+| validators | slots elapsed | state hash_tree_root |
+|---|---|---|
+| 64  | 1,000   | 0.13 ms |
+| 512 | 1,000   | 0.37 ms |
+| 64  | 21,000  | 1.84 ms |
+| 512 | 21,000  | 2.07 ms |
+| 512 | 100,000 | 8.60 ms |
+
+- **Slot count dominates, not validator count** (~14× from 1k→21k slots vs ~2.8×
+  from 64→512 validators); cost is ~linear in slots.
+- `VerifyStateRoot` ≈ pure HTR (2.09 vs 2.07 ms), 0 allocs — it's CPU-bound
+  merkleization, nothing else.
+
+This compounds: the block-builder's planner runs a trial transition per selection
+round, and every imported block pays it once — so at 21k+ slots the state root
+alone is milliseconds of CPU per block, squeezing the 800 ms interval budget and
+pushing time-to-finality and reorgs up.
+
+## Not fixable by pruning (spec finding)
+
+leanSpec `process_slots` appends to `historical_block_hashes` every slot and
+extends `justified_slots` per slot, retained up to `HISTORICAL_ROOTS_LIMIT`
+(2^18) with **no pruning below the limit**. The history is spec-mandated state,
+so gean cannot shrink it — the fix must make hashing it cheaper, not drop it.
+
+## Fix: cached (incremental) tree hashing — follow-up PR
+
+The history arrays are **append-only**: once written, `historical_block_hashes[i]`
+never changes, and `justified_slots` only extends and flips bits near the tip.
+So the SSZ merkle tree of those lists has a large stable prefix; only the path
+from the newly-appended leaves to the root changes per block. A cached tree hash
+(memoize merkle subtrees, recompute only dirtied paths) turns the per-block cost
+from O(slots) into O(Δ) — the standard beacon-client optimization.
+
+Deliberately **not** landed in this PR: it is consensus-critical (the cached root
+must equal the spec/sszgen root bit-for-bit), and `state.HashTreeRoot` is
+sszgen-generated (`*_encoding.go` is never hand-edited), so it needs a custom
+caching HTR path for the growing fields plus spec-fixture parity as the gate.
+That is a scoped change of its own, and this PR intentionally ships the
+measurement first so the optimization can be proven against a baseline.
+
+## Shipped in this PR
+
+- **Benchmark** (`state_scale_bench_test.go`) — reproducible, offline, no devnet;
+  the baseline for evaluating the caching work.
+- **Fat-LTO release profile** (`xmss/rust/Cargo.toml`) — whole-program inlining
+  across the prover/verifier, trimming the signature-verify CPU that is the
+  other half of import cost. opt-level stays 3 (the z/s miscompile guard holds).
+
+## Verified along the way
+
+- Out-of-range justified-slot votes: gean already rejects them
+  (`statetransition/votes.go` `IsSlotJustified` → `JustifiedSlotOutOfRangeError`),
+  matching leanSpec `JUSTIFIED_SLOT_OUT_OF_RANGE`. No action.
+
+## Not in scope (tracked elsewhere)
+
+- Two-tier "Goldfish" fork choice on a 4×1000 ms slot — a leanSpec-bound consensus
+  change still in draft upstream (fixtures not regenerated). Monitor leanSpec; it
+  will reshape `onTick`'s interval grid and `internal/forkchoice` when it lands.

--- a/internal/aggregation/aggregate.go
+++ b/internal/aggregation/aggregate.go
@@ -222,15 +222,15 @@ func aggregateFromSnapshot(snap *Snapshot, cache *xmss.PubKeyCache, deadline tim
 						continue
 					}
 
-					sigHandle := sigEntry.SigHandle
-					if sigHandle == nil {
-						parsed, err := xmss.ParseSignature(sigEntry.Signature[:])
-						if err != nil {
-							continue
-						}
-						defer xmss.FreeSignature(parsed)
-						sigHandle = parsed
+					// Parse a handle the worker owns and frees at the end of this
+					// group. The snapshot carries only bytes, never a handle shared
+					// with the live map, so a concurrent prune cannot free it underneath
+					// the prover.
+					sigHandle, err := xmss.ParseSignature(sigEntry.Signature[:])
+					if err != nil {
+						continue
 					}
+					defer xmss.FreeSignature(sigHandle)
 
 					pk, err := cache.Get(targetState.Validators[sigEntry.ValidatorID].AttestationPubkey)
 					if err != nil {

--- a/internal/aggregation/aggregate.go
+++ b/internal/aggregation/aggregate.go
@@ -15,14 +15,19 @@ import (
 )
 
 type aggregationGroup struct {
-	dataRoot [32]byte
-	slot     uint64
+	dataRoot   [32]byte
+	targetSlot uint64
 }
 
-// orderedGroups lists the snapshot's aggregation work newest-slot-first.
-// Fresh attestations are the only ones that can still influence
-// justification, so they must be proven inside the session budget; older
-// backlog only gets prover time the current slot doesn't need.
+// orderedGroups lists the snapshot's aggregation work frontier-first: by
+// ascending target slot. Finalization advances only when the checkpoint
+// immediately after the current source is justified (leanSpec
+// process_attestations finalizes a source when no justifiable slot sits between
+// it and its justified target). So when a backlog does not all fit the session
+// budget, spending it on the lowest unjustified targets keeps finalization
+// moving; ordering newest-first would advance the head while the finalization
+// frontier starves — the shape of the observed stall (head advancing, finality
+// lagging). Only the group order changes; every aggregate produced is spec-valid.
 func orderedGroups(snap *Snapshot) []aggregationGroup {
 	dataRoots := make(map[[32]byte]bool)
 	for dr := range snap.attSigs {
@@ -38,13 +43,20 @@ func orderedGroups(snap *Snapshot) []aggregationGroup {
 		if attData == nil {
 			continue
 		}
-		groups = append(groups, aggregationGroup{dataRoot: dr, slot: attData.Slot})
+		// The target checkpoint drives finalization; fall back to the attestation
+		// slot only for a malformed entry with no target (validation normally
+		// guarantees one).
+		targetSlot := attData.Slot
+		if attData.Target != nil {
+			targetSlot = attData.Target.Slot
+		}
+		groups = append(groups, aggregationGroup{dataRoot: dr, targetSlot: targetSlot})
 	}
 	sort.Slice(groups, func(i, j int) bool {
-		if groups[i].slot != groups[j].slot {
-			return groups[i].slot > groups[j].slot
+		if groups[i].targetSlot != groups[j].targetSlot {
+			return groups[i].targetSlot < groups[j].targetSlot
 		}
-		return bytes.Compare(groups[i].dataRoot[:], groups[j].dataRoot[:]) > 0
+		return bytes.Compare(groups[i].dataRoot[:], groups[j].dataRoot[:]) < 0
 	})
 	return groups
 }

--- a/internal/aggregation/aggregate.go
+++ b/internal/aggregation/aggregate.go
@@ -56,16 +56,54 @@ func orderedGroups(snap *Snapshot) []aggregationGroup {
 // converges to the real prover cost of whatever hardware runs the node.
 const seedPerUnitSeconds = 0.1
 
-// unitCostEstimator tracks observed per-unit aggregation-proving time so each pass
-// can be sized to the remaining session budget. The single-threaded worker holds
-// one across dispatches. No fixed unit cap would hold across machines and
-// validator-set sizes, so it self-calibrates instead.
+// seedPerGroupSeconds seeds the realized per-group wall-time estimate before any
+// group has been observed. It only governs the first group of the first session;
+// the estimate then tracks real hardware.
+const seedPerGroupSeconds = 0.3
+
+// unitCostEstimator tracks observed aggregation-proving time so each pass can be
+// sized to the remaining session budget. The single-threaded worker holds one
+// across dispatches. No fixed cap would hold across machines and validator-set
+// sizes, so it self-calibrates instead.
 type unitCostEstimator struct {
-	perUnitSeconds float64
+	perUnitSeconds  float64
+	perGroupSeconds float64
 }
 
 func newUnitCostEstimator() *unitCostEstimator {
+	// perGroupSeconds is left zero so the first observed group adopts its real
+	// cost directly (nextGroupDuration falls back to the seed until then). This
+	// makes the bound react within one group when proofs suddenly cost seconds,
+	// rather than easing toward it over many sessions.
 	return &unitCostEstimator{perUnitSeconds: seedPerUnitSeconds}
+}
+
+// nextGroupDuration estimates the wall time the next group will take (prep plus
+// recursive proof). The worker refuses to start a group when less than this
+// remains in the budget, so a session cannot overrun and hold the shared prover
+// past the slot — the overrun that starved block import and dropped the
+// aggregator off the chain at scale.
+func (e *unitCostEstimator) nextGroupDuration() time.Duration {
+	secs := seedPerGroupSeconds
+	if e != nil && e.perGroupSeconds > 0 {
+		secs = e.perGroupSeconds
+	}
+	return time.Duration(secs * float64(time.Second))
+}
+
+// observeGroup folds a completed group's realized wall time into the estimate
+// with an exponential moving average, so the bound tracks the cost growth that
+// comes with a larger state and validator set.
+func (e *unitCostEstimator) observeGroup(duration time.Duration) {
+	if e == nil || duration <= 0 {
+		return
+	}
+	const alpha = 0.3
+	if e.perGroupSeconds <= 0 {
+		e.perGroupSeconds = duration.Seconds()
+		return
+	}
+	e.perGroupSeconds = alpha*duration.Seconds() + (1-alpha)*e.perGroupSeconds
 }
 
 // maxUnitsWithin reports how many units fit in the remaining budget at the current
@@ -109,11 +147,18 @@ func aggregateFromSnapshot(snap *Snapshot, cache *xmss.PubKeyCache, deadline tim
 	truncated := false
 
 	for _, group := range orderedGroups(snap) {
-		if !deadline.IsZero() && time.Now().After(deadline) {
+		// Hard budget bound: never start a proof that cannot finish in the time
+		// left. A session that overruns keeps the shared prover past the slot and
+		// starves block import — the failure that dropped the aggregator off the
+		// chain at scale. Stop cleanly and leave this slot's aggregate partial;
+		// the deferred groups' signatures remain in the store for the next session.
+		if !deadline.IsZero() && time.Until(deadline) < estimator.nextGroupDuration() {
 			truncated = true
 			break
 		}
 		dataRoot := group.dataRoot
+		groupStart := time.Now()
+		provedBefore := len(newAggregates)
 		func() {
 			childProofsBuf := getChildProofsBuf()
 			defer putChildProofsBuf(childProofsBuf)
@@ -262,6 +307,11 @@ func aggregateFromSnapshot(snap *Snapshot, cache *xmss.PubKeyCache, deadline tim
 				}
 			}
 		}()
+		// Only groups that actually proved inform the wall-time estimate; skipped
+		// groups (too few signatures) return fast and would bias it low.
+		if len(newAggregates) > provedBefore {
+			estimator.observeGroup(time.Since(groupStart))
+		}
 	}
 
 	return newAggregates, payloadEntries, keysToDelete, truncated

--- a/internal/aggregation/aggregate.go
+++ b/internal/aggregation/aggregate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/geanlabs/gean/internal/logger"
 	"github.com/geanlabs/gean/internal/metrics"
 	"github.com/geanlabs/gean/internal/shadow"
+	"github.com/geanlabs/gean/internal/statetransition"
 	"github.com/geanlabs/gean/internal/store"
 	"github.com/geanlabs/gean/internal/types"
 	"github.com/geanlabs/gean/xmss"
@@ -49,6 +50,18 @@ func orderedGroups(snap *Snapshot) []aggregationGroup {
 		targetSlot := attData.Slot
 		if attData.Target != nil {
 			targetSlot = attData.Target.Slot
+		}
+		// Skip targets already justified in the head state. process_attestations
+		// ignores a vote once its target is justified, so proving it spends the
+		// session budget on an aggregate that can no longer advance finality —
+		// budget that a still-unjustified target needs. Only a definite "yes"
+		// skips: an out-of-range target (beyond the tracked bitfield, i.e. a fresh
+		// slot) returns an error and is kept.
+		if snap.headState != nil && snap.headState.LatestFinalized != nil {
+			justified, err := statetransition.IsSlotJustified(snap.headState, snap.headState.LatestFinalized.Slot, targetSlot)
+			if err == nil && justified {
+				continue
+			}
 		}
 		groups = append(groups, aggregationGroup{dataRoot: dr, targetSlot: targetSlot})
 	}

--- a/internal/aggregation/aggregate_test.go
+++ b/internal/aggregation/aggregate_test.go
@@ -72,23 +72,6 @@ func aggregateTestSnapshot(slots ...uint64) *Snapshot {
 	return snap
 }
 
-func TestOrderedGroupsNewestFirst(t *testing.T) {
-	snap := aggregateTestSnapshot(3, 9, 1, 9)
-
-	groups := orderedGroups(snap)
-	if len(groups) != 4 {
-		t.Fatalf("groups=%d, want 4", len(groups))
-	}
-	for i := 1; i < len(groups); i++ {
-		if groups[i].slot > groups[i-1].slot {
-			t.Fatalf("groups not newest-first at %d: %d after %d", i, groups[i].slot, groups[i-1].slot)
-		}
-	}
-	if groups[0].slot != 9 || groups[len(groups)-1].slot != 1 {
-		t.Fatalf("order=%v", groups)
-	}
-}
-
 func TestAggregateFromSnapshotExpiredDeadlineReportsTruncation(t *testing.T) {
 	snap := aggregateTestSnapshot(5)
 	cache := xmss.NewPubKeyCache()

--- a/internal/aggregation/ordering_test.go
+++ b/internal/aggregation/ordering_test.go
@@ -1,0 +1,94 @@
+package aggregation
+
+import (
+	"testing"
+
+	"github.com/geanlabs/gean/internal/store"
+	"github.com/geanlabs/gean/internal/types"
+)
+
+func rootByte(b byte) [32]byte {
+	var r [32]byte
+	r[0] = b
+	return r
+}
+
+// snapshotWithTargets builds a snapshot whose only content is one attestation
+// group per entry, each voting for the given target slot.
+func snapshotWithTargets(targets map[byte]uint64) *Snapshot {
+	attSigs := make(map[[32]byte]*store.AttestationDataEntry, len(targets))
+	for id, targetSlot := range targets {
+		attSigs[rootByte(id)] = &store.AttestationDataEntry{
+			Data: &types.AttestationData{
+				Slot:   targetSlot,
+				Target: &types.Checkpoint{Slot: targetSlot},
+			},
+		}
+	}
+	return &Snapshot{attSigs: attSigs}
+}
+
+// TestOrderedGroupsFrontierFirst: groups come out by ascending target slot, so
+// the votes nearest the finalized frontier are proven before the head-most ones.
+func TestOrderedGroupsFrontierFirst(t *testing.T) {
+	snap := snapshotWithTargets(map[byte]uint64{1: 104, 2: 100, 3: 102, 4: 101, 5: 103})
+	ordered := orderedGroups(snap)
+
+	want := []uint64{100, 101, 102, 103, 104}
+	if len(ordered) != len(want) {
+		t.Fatalf("group count=%d, want %d", len(ordered), len(want))
+	}
+	for i, g := range ordered {
+		if g.targetSlot != want[i] {
+			t.Fatalf("position %d targetSlot=%d, want %d", i, g.targetSlot, want[i])
+		}
+	}
+}
+
+// TestTruncatingAggregatorKeepsFrontier: with a session budget that covers only
+// the first few groups, frontier-first keeps the finalization-frontier votes and
+// yields the head-most ones. The former newest-first order did the inverse —
+// spending the budget on the head while the frontier starved, which advances the
+// head but stalls finalization (the observed stall shape).
+func TestTruncatingAggregatorKeepsFrontier(t *testing.T) {
+	const frontier = uint64(100)
+	const headMost = uint64(104)
+	snap := snapshotWithTargets(map[byte]uint64{1: frontier, 2: 101, 3: 102, 4: 103, 5: headMost})
+
+	ordered := orderedGroups(snap)
+
+	// A budget that fits only the first two proofs.
+	const budget = 2
+	proven := make(map[uint64]bool)
+	for _, g := range ordered[:budget] {
+		proven[g.targetSlot] = true
+	}
+
+	if !proven[frontier] {
+		t.Fatalf("frontier target %d dropped under truncation", frontier)
+	}
+	if proven[headMost] {
+		t.Fatal("head-most target proven before the frontier under truncation")
+	}
+}
+
+// TestOrderedGroupsDeterministicTiebreak: equal target slots break ties by data
+// root, so the order is stable across snapshots regardless of map iteration.
+func TestOrderedGroupsDeterministicTiebreak(t *testing.T) {
+	snap := snapshotWithTargets(map[byte]uint64{9: 50, 3: 50, 7: 50})
+	first := orderedGroups(snap)
+	for range 5 {
+		again := orderedGroups(snap)
+		for i := range first {
+			if first[i].dataRoot != again[i].dataRoot {
+				t.Fatalf("non-deterministic order at %d", i)
+			}
+		}
+	}
+	// All equal target; must be ascending by data root.
+	for i := 1; i < len(first); i++ {
+		if first[i-1].dataRoot[0] > first[i].dataRoot[0] {
+			t.Fatalf("tiebreak not ascending by data root: %d before %d", first[i-1].dataRoot[0], first[i].dataRoot[0])
+		}
+	}
+}

--- a/internal/aggregation/ordering_test.go
+++ b/internal/aggregation/ordering_test.go
@@ -72,6 +72,38 @@ func TestTruncatingAggregatorKeepsFrontier(t *testing.T) {
 	}
 }
 
+// TestOrderedGroupsSkipsJustifiedTargets: a group whose target is already
+// justified in the head state is dropped, so the session budget goes to targets
+// that can still advance finality. An out-of-range (fresh) target is kept.
+func TestOrderedGroupsSkipsJustifiedTargets(t *testing.T) {
+	const finalized = uint64(100)
+	const justifiedTarget = uint64(105)
+	const openTarget = uint64(106)
+
+	justifiedSlots := types.BitlistExtend(nil, 10)
+	types.BitlistSet(justifiedSlots, justifiedTarget-finalized-1) // mark slot 105 justified
+	headState := &types.State{
+		LatestFinalized: &types.Checkpoint{Slot: finalized},
+		JustifiedSlots:  justifiedSlots,
+	}
+
+	snap := &Snapshot{
+		headState: headState,
+		attSigs: map[[32]byte]*store.AttestationDataEntry{
+			rootByte(1): {Data: &types.AttestationData{Slot: justifiedTarget, Target: &types.Checkpoint{Slot: justifiedTarget}}},
+			rootByte(2): {Data: &types.AttestationData{Slot: openTarget, Target: &types.Checkpoint{Slot: openTarget}}},
+		},
+	}
+
+	ordered := orderedGroups(snap)
+	if len(ordered) != 1 {
+		t.Fatalf("groups=%d, want 1 (justified target skipped)", len(ordered))
+	}
+	if ordered[0].targetSlot != openTarget {
+		t.Fatalf("kept target=%d, want %d (the still-open one)", ordered[0].targetSlot, openTarget)
+	}
+}
+
 // TestOrderedGroupsDeterministicTiebreak: equal target slots break ties by data
 // root, so the order is stable across snapshots regardless of map iteration.
 func TestOrderedGroupsDeterministicTiebreak(t *testing.T) {

--- a/internal/aggregation/session_bound_test.go
+++ b/internal/aggregation/session_bound_test.go
@@ -1,0 +1,57 @@
+package aggregation
+
+import (
+	"testing"
+	"time"
+)
+
+// TestEstimatorSeedGroupDuration: before any group is observed the estimator
+// reports the seed, so the very first session still attempts a group.
+func TestEstimatorSeedGroupDuration(t *testing.T) {
+	e := newUnitCostEstimator()
+	want := time.Duration(seedPerGroupSeconds * float64(time.Second))
+	if got := e.nextGroupDuration(); got != want {
+		t.Fatalf("seed nextGroupDuration=%v, want %v", got, want)
+	}
+	// Nil receiver must not panic and must fall back to the seed.
+	var nilEst *unitCostEstimator
+	if got := nilEst.nextGroupDuration(); got != want {
+		t.Fatalf("nil nextGroupDuration=%v, want %v", got, want)
+	}
+}
+
+// TestEstimatorTracksGroupCost: the estimate follows observed per-group wall
+// time via EMA, so the bound rises as proofs get more expensive with scale.
+func TestEstimatorTracksGroupCost(t *testing.T) {
+	e := newUnitCostEstimator()
+	// First observation seeds the running value directly.
+	e.observeGroup(2 * time.Second)
+	if got := e.nextGroupDuration(); got < 1900*time.Millisecond || got > 2100*time.Millisecond {
+		t.Fatalf("after first observe nextGroupDuration=%v, want ~2s", got)
+	}
+	// Repeated 2s observations converge toward 2s.
+	for range 10 {
+		e.observeGroup(2 * time.Second)
+	}
+	if got := e.nextGroupDuration(); got < 1900*time.Millisecond || got > 2100*time.Millisecond {
+		t.Fatalf("converged nextGroupDuration=%v, want ~2s", got)
+	}
+}
+
+// TestSessionBoundRefusesUnfinishableProof: once the estimate exceeds the
+// remaining budget, the worker's gate predicate refuses to start another proof
+// — the check that stops a session overrunning and starving block import.
+func TestSessionBoundRefusesUnfinishableProof(t *testing.T) {
+	e := newUnitCostEstimator()
+	for range 5 {
+		e.observeGroup(2 * time.Second)
+	}
+	// 500ms left, but a group now costs ~2s: must refuse.
+	if 500*time.Millisecond >= e.nextGroupDuration() {
+		t.Fatal("expected 500ms remaining to be below the per-group estimate")
+	}
+	// 3s left: may proceed.
+	if 3*time.Second < e.nextGroupDuration() {
+		t.Fatal("expected 3s remaining to be above the per-group estimate")
+	}
+}

--- a/internal/blockbuilder/build.go
+++ b/internal/blockbuilder/build.go
@@ -19,6 +19,8 @@ func Build(input Input) (*Result, error) {
 	if err != nil {
 		return nil, err
 	}
+	metrics.ObserveBlockProposalAttestationDataSelected(len(plan.attestations))
+	metrics.ObserveBlockProposalAggregatesSelected(len(plan.proofs))
 
 	finalBlock := newBlock(input.Slot, input.ProposerIndex, input.ParentRoot, plan.attestations)
 	stateRoot, err := plan.postState.HashTreeRoot()

--- a/internal/blockbuilder/plan.go
+++ b/internal/blockbuilder/plan.go
@@ -3,6 +3,7 @@ package blockbuilder
 import (
 	"fmt"
 
+	"github.com/geanlabs/gean/internal/metrics"
 	"github.com/geanlabs/gean/internal/types"
 )
 
@@ -116,6 +117,7 @@ func (p *planner) tryPayload(payload AttestationPayload) bool {
 
 	p.attestations = append(p.attestations, att)
 	p.proofs = append(p.proofs, sig)
+	metrics.IncBlockProposalAttestationBuilds()
 	return true
 }
 

--- a/internal/metrics/counters.go
+++ b/internal/metrics/counters.go
@@ -82,4 +82,8 @@ var (
 		Name: "lean_p2p_reqresp_timeout_total",
 		Help: "Req/resp stream operations aborted by the idle deadline, by protocol and direction",
 	}, []string{"protocol", "direction"})
+	metricBlockProposalAttestationBuilds = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "lean_block_proposal_attestation_builds_total",
+		Help: "Payloads selected into the proposal during greedy attestation planning",
+	})
 )

--- a/internal/metrics/gauges.go
+++ b/internal/metrics/gauges.go
@@ -84,4 +84,7 @@ var (
 	metricProcessRSSBytes = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "lean_node_rss_bytes", Help: "Process resident set size in bytes (includes prover memory outside the Go heap)",
 	})
+	metricTableBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "lean_table_bytes", Help: "Estimated on-disk byte size of a storage table",
+	}, []string{"table"})
 )

--- a/internal/metrics/histograms.go
+++ b/internal/metrics/histograms.go
@@ -135,4 +135,24 @@ var (
 		Name: "lean_proof_merge_components", Help: "Type-1 components merged into a Type-2 proof",
 		Buckets: []float64{1, 2, 3, 4, 5, 6, 7, 8, 9},
 	})
+	metricReqRespRequestSize = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "lean_reqresp_request_size_bytes",
+		Help:    "On-wire bytes of a req/resp request frame",
+		Buckets: []float64{64, 128, 256, 512, 1024, 4096, 16384, 65536},
+	}, []string{"protocol"})
+	metricReqRespResponseChunkSize = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "lean_reqresp_response_chunk_size_bytes",
+		Help:    "On-wire bytes of a single req/resp response frame",
+		Buckets: []float64{128, 1024, 10000, 100000, 500000, 1000000, 5000000, 10000000},
+	}, []string{"protocol"})
+	metricBlockProposalAttestationDataSelected = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "lean_block_proposal_attestation_data_selected",
+		Help:    "Distinct AttestationData entries placed in the proposal block body",
+		Buckets: []float64{0, 1, 2, 4, 8, 16, 32},
+	})
+	metricBlockProposalAggregatesSelected = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "lean_block_proposal_aggregates_selected",
+		Help:    "Aggregated signature proofs selected for the proposal",
+		Buckets: []float64{0, 1, 2, 4, 8, 16, 32, 64, 128},
+	})
 )

--- a/internal/metrics/inc.go
+++ b/internal/metrics/inc.go
@@ -39,3 +39,5 @@ func IncPeerDisconnection(direction, reason string) {
 func IncReqRespTimeout(protocol, direction string) {
 	metricReqRespTimeout.WithLabelValues(labelOrUnknown(protocol), labelOrUnknown(direction)).Inc()
 }
+
+func IncBlockProposalAttestationBuilds() { metricBlockProposalAttestationBuilds.Inc() }

--- a/internal/metrics/observe.go
+++ b/internal/metrics/observe.go
@@ -73,3 +73,19 @@ func ObserveProofSize(proofType string, bytes int) {
 func ObserveProofMergeComponents(n int) {
 	observeNonNegative(metricProofMergeComponents, countValue(n))
 }
+
+func ObserveReqRespRequestSize(protocol string, bytes int) {
+	observeNonNegative(metricReqRespRequestSize.WithLabelValues(labelOrUnknown(protocol)), countValue(bytes))
+}
+
+func ObserveReqRespResponseChunkSize(protocol string, bytes int) {
+	observeNonNegative(metricReqRespResponseChunkSize.WithLabelValues(labelOrUnknown(protocol)), countValue(bytes))
+}
+
+func ObserveBlockProposalAttestationDataSelected(n int) {
+	observeNonNegative(metricBlockProposalAttestationDataSelected, countValue(n))
+}
+
+func ObserveBlockProposalAggregatesSelected(n int) {
+	observeNonNegative(metricBlockProposalAggregatesSelected, countValue(n))
+}

--- a/internal/metrics/set.go
+++ b/internal/metrics/set.go
@@ -52,3 +52,7 @@ func SetAttestationAggregateCoverageDiffValidators(direction string, n int) {
 	metricAttestationAggregateCoverageDiffValidators.
 		WithLabelValues(labelOrUnknown(direction)).Set(countValue(n))
 }
+
+func SetTableBytes(table string, bytes uint64) {
+	metricTableBytes.WithLabelValues(labelOrUnknown(table)).Set(float64(bytes))
+}

--- a/internal/node/dispatch.go
+++ b/internal/node/dispatch.go
@@ -17,6 +17,9 @@ func (e *Engine) dispatch(ctx context.Context, ticks <-chan time.Time) {
 		case <-ticks:
 			e.onTick()
 
+		case <-e.EarlyAggregateCh:
+			e.maybeEarlyAggregate(uint64(time.Now().UnixMilli()))
+
 		case block := <-e.BlockCh:
 			e.onBlock(block)
 

--- a/internal/node/duties.go
+++ b/internal/node/duties.go
@@ -8,7 +8,6 @@ import (
 	"github.com/geanlabs/gean/internal/logger"
 	"github.com/geanlabs/gean/internal/metrics"
 	"github.com/geanlabs/gean/internal/types"
-	"github.com/geanlabs/gean/xmss"
 )
 
 func (e *Engine) produceAttestations(slot uint64) {
@@ -51,8 +50,7 @@ func (e *Engine) produceAttestations(slot uint64) {
 				logger.Error(logger.Validator, "attestation root failed validator=%d: %v", vid, err)
 				continue
 			}
-			sigHandle, parseErr := xmss.ParseSignature(sig[:])
-			e.Store.AttestationSignatures.InsertWithHandle(dataRoot, attData, vid, sig, sigHandle, parseErr)
+			e.Store.AttestationSignatures.Insert(dataRoot, attData, vid, sig)
 		}
 
 		if e.P2P != nil {

--- a/internal/node/engine.go
+++ b/internal/node/engine.go
@@ -49,6 +49,12 @@ type Engine struct {
 	FailedRootCh  chan [32]byte
 	FetchRootCh   chan [32]byte
 
+	// EarlyAggregateCh is a coalescing (capacity-1) wake-up: an attestation-verify
+	// goroutine pokes it after inserting a signature, and the dispatch loop reacts
+	// by considering an early aggregation session. It carries no data — the loop
+	// re-reads live store state — so a full channel is simply dropped.
+	EarlyAggregateCh chan struct{}
+
 	AggregationDispatchCh chan aggregation.Dispatch
 	ProposalCh            chan proposalDuty
 	ProposalResultCh      chan *proposalResult
@@ -68,6 +74,18 @@ type Engine struct {
 	// missing parent cannot flood FetchRootCh with duplicate requests. Accessed only
 	// on the dispatch loop (queue on onBlock, clear on receive/exhaustion), so no lock.
 	fetchInFlight map[[32]byte]bool
+
+	// aggregatedSlot is the last slot for which an aggregation session was
+	// dispatched, so the early (attestation-arrival) path and the interval-2
+	// fallback dispatch at most once per slot. Written and read only on the
+	// single dispatch loop, so no lock.
+	aggregatedSlot uint64
+
+	// numValidators caches the validator-set size, fixed at genesis in lean
+	// devnet, used as the denominator for the early-aggregation quorum. Filled
+	// lazily on the dispatch loop to avoid SSZ-decoding the head state on every
+	// attestation arrival; read/written only there, so no lock.
+	numValidators uint64
 }
 
 func New(
@@ -99,6 +117,7 @@ func New(
 		AggregationCh:         make(chan *types.SignedAggregatedAttestation, 64),
 		FailedRootCh:          make(chan [32]byte, 64),
 		FetchRootCh:           make(chan [32]byte, 256),
+		EarlyAggregateCh:      make(chan struct{}, 1),
 		AggregationDispatchCh: make(chan aggregation.Dispatch, 1),
 		ProposalCh:            make(chan proposalDuty, 1),
 		ProposalResultCh:      make(chan *proposalResult, 1),

--- a/internal/node/gossip.go
+++ b/internal/node/gossip.go
@@ -64,6 +64,14 @@ func (e *Engine) onGossipAttestation(att *types.SignedAttestation) {
 	logger.Info(logger.Gossip, "attestation verified: validator=%d slot=%d dataRoot=%x", att.ValidatorID, att.Data.Slot, dataRoot)
 	e.Store.AttestationSignatures.InsertWithHandle(dataRoot, att.Data, att.ValidatorID, att.Signature, sigHandle, parseErr)
 	success = true
+
+	// Nudge the dispatch loop to consider aggregating early now that another vote
+	// is in. The signal is best-effort and coalescing; the loop owns the actual
+	// timing and quorum decision.
+	select {
+	case e.EarlyAggregateCh <- struct{}{}:
+	default:
+	}
 }
 
 func (e *Engine) onGossipAggregatedAttestation(agg *types.SignedAggregatedAttestation) {

--- a/internal/node/gossip.go
+++ b/internal/node/gossip.go
@@ -8,7 +8,6 @@ import (
 	"github.com/geanlabs/gean/internal/metrics"
 	"github.com/geanlabs/gean/internal/store"
 	"github.com/geanlabs/gean/internal/types"
-	"github.com/geanlabs/gean/xmss"
 )
 
 func (e *Engine) onGossipAttestation(att *types.SignedAttestation) {
@@ -59,10 +58,8 @@ func (e *Engine) onGossipAttestation(att *types.SignedAttestation) {
 	metrics.IncPqSigAttestationSigsValid()
 	metrics.IncAttestationsValid(1)
 
-	sigHandle, parseErr := xmss.ParseSignature(att.Signature[:])
-
 	logger.Info(logger.Gossip, "attestation verified: validator=%d slot=%d dataRoot=%x", att.ValidatorID, att.Data.Slot, dataRoot)
-	e.Store.AttestationSignatures.InsertWithHandle(dataRoot, att.Data, att.ValidatorID, att.Signature, sigHandle, parseErr)
+	e.Store.AttestationSignatures.Insert(dataRoot, att.Data, att.ValidatorID, att.Signature)
 	success = true
 
 	// Nudge the dispatch loop to consider aggregating early now that another vote

--- a/internal/node/import.go
+++ b/internal/node/import.go
@@ -3,6 +3,8 @@ package node
 import (
 	"github.com/geanlabs/gean/internal/blockprocessor"
 	"github.com/geanlabs/gean/internal/logger"
+	"github.com/geanlabs/gean/internal/metrics"
+	"github.com/geanlabs/gean/internal/storage"
 	"github.com/geanlabs/gean/internal/types"
 )
 
@@ -74,9 +76,22 @@ func (e *Engine) importKnownParentBlock(
 	e.dispatchRecovery(signedBlock)
 
 	e.FC.OnBlock(block.Slot, blockRoot, parentRoot)
+	e.recordTableBytes()
 
 	e.updateHead()
 	e.Pending.ClearDepth(blockRoot)
 	e.replayPendingAttestations(blockRoot)
 	e.collectPendingChildren(blockRoot, queue)
+}
+
+// recordTableBytes refreshes the per-table storage-size gauge after a block is
+// persisted. Runs on the single-threaded import path, so the estimate reflects
+// the just-applied write with no locking concerns.
+func (e *Engine) recordTableBytes() {
+	if e.Store == nil || e.Store.Backend == nil {
+		return
+	}
+	for _, table := range storage.AllTables {
+		metrics.SetTableBytes(string(table), e.Store.Backend.EstimateTableBytes(table))
+	}
 }

--- a/internal/node/tick.go
+++ b/internal/node/tick.go
@@ -66,6 +66,12 @@ func (e *Engine) dispatchAggregationCycle(currentSlot uint64, isAggregator bool)
 		metrics.IncAggregatorSkipped(metrics.AggregatorSkipNotAggregator)
 		return
 	}
+	// Dispatch at most once per slot: the early attestation-arrival path and the
+	// interval-2 fallback both route here, and the recursive proof is far too
+	// expensive to run twice for the same slot.
+	if currentSlot == e.aggregatedSlot {
+		return
+	}
 	// The sync-lag duty gate is spec-defined only for block and attestation; gean
 	// also applies it to aggregation. Aggregating on a stale view only produces
 	// best-effort aggregates that get dropped, so gating when lagging is safe and
@@ -90,11 +96,63 @@ func (e *Engine) dispatchAggregationCycle(currentSlot uint64, isAggregator bool)
 	}
 	select {
 	case e.AggregationDispatchCh <- aggregation.Dispatch{Snapshot: snap, Slot: currentSlot}:
+		e.aggregatedSlot = currentSlot
 		metrics.SetProvingQueueDepth("aggregation", len(e.AggregationDispatchCh))
 	default:
 		metrics.IncAggregationDispatchDropped()
 		metrics.IncAggregatorSkipped(metrics.AggregatorSkipSpawnFailed)
 	}
+}
+
+// maybeEarlyAggregate starts the aggregation session in late interval 1, once this
+// slot's votes have reached quorum — a partial-interval lead ahead of the interval-2
+// fallback — so the slow recursive proof gets a head start toward finishing inside
+// its budget instead of racing the interval boundary and truncating. Gating on the
+// slot's own vote count rather than a wall-clock lead keeps the timing tied to the
+// slot model. It only moves *when the proving starts*: the aggregate still covers
+// same-slot attestations and is gossiped within the slot, so it is spec-neutral.
+// dispatchAggregationCycle enforces the once-per-slot guard shared with the
+// interval-2 fallback.
+func (e *Engine) maybeEarlyAggregate(nowMs uint64) {
+	isAgg := e.AggCtl != nil && e.AggCtl.Get()
+	if !isAgg || e.currentInterval(nowMs) != 1 {
+		return
+	}
+	slot := e.currentSlot(nowMs)
+	if slot == e.aggregatedSlot {
+		return
+	}
+	// Validator set is fixed at genesis in lean devnet, so decode the head state
+	// once and cache the count rather than on every arrival.
+	if e.numValidators == 0 {
+		headState := e.Store.GetState(e.Store.Head())
+		if headState == nil {
+			return
+		}
+		e.numValidators = headState.NumValidators()
+		if e.numValidators == 0 {
+			return
+		}
+	}
+	// Only pull the session forward once a finalizing supermajority of *this slot's*
+	// votes is already collected. The count must be scoped to the current slot: a
+	// cross-slot backlog would satisfy the threshold at the very start of interval 1,
+	// before the slot's own attestations have propagated, and bundling then starves
+	// justification. Scoped to the slot, the threshold is reached only in late
+	// interval 1 once votes are in — a modest proving lead that still carries
+	// decisive weight, with the interval-2 dispatch as the fallback below quorum.
+	if e.Store.AttestationSignatures.SignatureCountForSlot(slot) < earlyAggregationQuorum(e.numValidators) {
+		return
+	}
+	e.dispatchAggregationCycle(slot, isAgg)
+}
+
+// earlyAggregationQuorum is the 3SF supermajority ceil(2n/3) — the same threshold
+// the fork choice uses for justification. At that many collected votes an early
+// aggregate already carries finalizing weight, so proving it ahead of interval 2
+// is worthwhile.
+func earlyAggregationQuorum(numValidators uint64) int {
+	return int((2*numValidators + 2) / 3)
 }
 
 func (e *Engine) runAttestationInterval(currentSlot uint64) {

--- a/internal/node/tick.go
+++ b/internal/node/tick.go
@@ -58,10 +58,6 @@ func (e *Engine) onTick() {
 	if currentInterval == 3 {
 		e.updateSafeTarget()
 		store.PeriodicPrune(e.Store, e.FC, currentSlot, e.Store.LatestFinalized().Slot)
-		// Cap the pending-signature backlog to a bounded window behind head.
-		// Finalization pruning alone lets it grow without bound when finality
-		// stalls, inflating each aggregation session and feeding the stall.
-		e.Store.AttestationSignatures.PruneBacklog(e.Store.HeadSlot())
 	}
 }
 

--- a/internal/node/tick.go
+++ b/internal/node/tick.go
@@ -58,6 +58,10 @@ func (e *Engine) onTick() {
 	if currentInterval == 3 {
 		e.updateSafeTarget()
 		store.PeriodicPrune(e.Store, e.FC, currentSlot, e.Store.LatestFinalized().Slot)
+		// Cap the pending-signature backlog to a bounded window behind head.
+		// Finalization pruning alone lets it grow without bound when finality
+		// stalls, inflating each aggregation session and feeding the stall.
+		e.Store.AttestationSignatures.PruneBacklog(e.Store.HeadSlot())
 	}
 }
 

--- a/internal/node/tick_test.go
+++ b/internal/node/tick_test.go
@@ -1,0 +1,28 @@
+package node
+
+import "testing"
+
+// TestEarlyAggregationQuorum pins the early-dispatch threshold to the 3SF
+// supermajority ceil(2n/3). An off-by-one here would either fire the early
+// session before enough votes are in (poor coverage) or never fire it (no head
+// start), so the boundary is verified against hand-computed ceil(2n/3).
+func TestEarlyAggregationQuorum(t *testing.T) {
+	cases := []struct {
+		n    uint64
+		want int
+	}{
+		{0, 0},
+		{1, 1},
+		{2, 2},
+		{3, 2},
+		{4, 3},
+		{5, 4},
+		{10, 7},
+		{100, 67},
+	}
+	for _, c := range cases {
+		if got := earlyAggregationQuorum(c.n); got != c.want {
+			t.Errorf("earlyAggregationQuorum(%d)=%d, want %d", c.n, got, c.want)
+		}
+	}
+}

--- a/internal/p2p/range.go
+++ b/internal/p2p/range.go
@@ -13,6 +13,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/protocol"
 
 	"github.com/geanlabs/gean/internal/logger"
+	"github.com/geanlabs/gean/internal/metrics"
 	"github.com/geanlabs/gean/internal/types"
 )
 
@@ -103,7 +104,9 @@ func (h *Host) FetchBlocksByRange(
 		return nil, fmt.Errorf("marshal blocks_by_range request: %w", err)
 	}
 	armWriteDeadline(stream)
-	if _, err := stream.Write(EncodeReqRespPayload(reqSSZ)); err != nil {
+	reqBytes := EncodeReqRespPayload(reqSSZ)
+	metrics.ObserveReqRespRequestSize("blocks_by_range", len(reqBytes))
+	if _, err := stream.Write(reqBytes); err != nil {
 		return nil, fmt.Errorf("write blocks_by_range request: %w", err)
 	}
 	stream.CloseWrite()

--- a/internal/p2p/response.go
+++ b/internal/p2p/response.go
@@ -11,7 +11,9 @@ import (
 // that stops reading cannot hold an inbound handler open indefinitely.
 func writeResponse(s network.Stream, label string, code byte, data []byte) bool {
 	armWriteDeadline(s)
-	if _, err := s.Write(EncodeResponse(code, data)); err != nil {
+	encoded := EncodeResponse(code, data)
+	metrics.ObserveReqRespResponseChunkSize(label, len(encoded))
+	if _, err := s.Write(encoded); err != nil {
 		if isStreamTimeout(err) {
 			metrics.IncReqRespTimeout(label, "write")
 		}

--- a/internal/p2p/roots.go
+++ b/internal/p2p/roots.go
@@ -13,6 +13,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/protocol"
 
 	"github.com/geanlabs/gean/internal/logger"
+	"github.com/geanlabs/gean/internal/metrics"
 	"github.com/geanlabs/gean/internal/types"
 )
 
@@ -82,7 +83,9 @@ func (h *Host) FetchBlocksByRoot(ctx context.Context, peerID peer.ID, roots [][3
 	defer stream.Close()
 
 	armWriteDeadline(stream)
-	if _, err := stream.Write(EncodeReqRespPayload(EncodeBlocksByRootRequest(roots))); err != nil {
+	reqBytes := EncodeReqRespPayload(EncodeBlocksByRootRequest(roots))
+	metrics.ObserveReqRespRequestSize("blocks_by_root", len(reqBytes))
+	if _, err := stream.Write(reqBytes); err != nil {
 		return nil, fmt.Errorf("write blocks request: %w", err)
 	}
 	stream.CloseWrite()

--- a/internal/p2p/status.go
+++ b/internal/p2p/status.go
@@ -11,6 +11,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/protocol"
 
 	"github.com/geanlabs/gean/internal/logger"
+	"github.com/geanlabs/gean/internal/metrics"
 )
 
 const statusMessageSize = 80
@@ -93,7 +94,9 @@ func (h *Host) SendStatusRequest(ctx context.Context, peerID peer.ID, ourStatus 
 	defer stream.Close()
 
 	armWriteDeadline(stream)
-	if _, err := stream.Write(EncodeReqRespPayload(ourStatus.MarshalSSZ())); err != nil {
+	reqBytes := EncodeReqRespPayload(ourStatus.MarshalSSZ())
+	metrics.ObserveReqRespRequestSize("status", len(reqBytes))
+	if _, err := stream.Write(reqBytes); err != nil {
 		return nil, fmt.Errorf("write status request: %w", err)
 	}
 	stream.CloseWrite()

--- a/internal/statetransition/state_scale_bench_test.go
+++ b/internal/statetransition/state_scale_bench_test.go
@@ -1,0 +1,85 @@
+package statetransition
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/geanlabs/gean/internal/types"
+)
+
+// syntheticState builds a state with numValidators validators and its per-slot
+// history arrays (historical_block_hashes, justified_slots) sized to historyLen,
+// standing in for a chain that has advanced historyLen slots. This isolates the
+// state hash-tree-root cost — the dominant, slot-growing term in block import
+// (VerifyStateRoot re-merkleizes the whole state per block) — without needing a
+// live devnet or any crypto/FFI.
+func syntheticState(numValidators, historyLen int) *types.State {
+	validators := make([]*types.Validator, numValidators)
+	for i := range validators {
+		var pk [types.PubkeySize]byte
+		binary.LittleEndian.PutUint64(pk[:], uint64(i+1))
+		validators[i] = &types.Validator{AttestationPubkey: pk, ProposalPubkey: pk, Index: uint64(i)}
+	}
+
+	hbh := make([][]byte, historyLen)
+	for i := range hbh {
+		entry := make([]byte, types.RootSize)
+		binary.LittleEndian.PutUint64(entry, uint64(i+1))
+		hbh[i] = entry
+	}
+
+	return &types.State{
+		Config:                   &types.ChainConfig{GenesisTime: 1000},
+		Slot:                     uint64(historyLen),
+		LatestBlockHeader:        &types.BlockHeader{Slot: uint64(historyLen)},
+		LatestJustified:          &types.Checkpoint{},
+		LatestFinalized:          &types.Checkpoint{},
+		HistoricalBlockHashes:    hbh,
+		JustifiedSlots:           types.NewBitlistSSZ(uint64(historyLen)),
+		Validators:               validators,
+		JustificationsRoots:      [][]byte{},
+		JustificationsValidators: types.NewBitlistSSZ(0),
+	}
+}
+
+// benchStateHashTreeRoot measures the per-block state-root cost the import path
+// pays in VerifyStateRoot. Grid the two growth axes — validator count and slot
+// history — to see which dominates at scale.
+func benchStateHashTreeRoot(b *testing.B, numValidators, historyLen int) {
+	state := syntheticState(numValidators, historyLen)
+	if _, err := state.HashTreeRoot(); err != nil {
+		b.Fatalf("initial hash_tree_root: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := state.HashTreeRoot(); err != nil {
+			b.Fatalf("hash_tree_root: %v", err)
+		}
+	}
+}
+
+func BenchmarkStateHashTreeRoot_v64_s1000(b *testing.B)    { benchStateHashTreeRoot(b, 64, 1000) }
+func BenchmarkStateHashTreeRoot_v512_s1000(b *testing.B)   { benchStateHashTreeRoot(b, 512, 1000) }
+func BenchmarkStateHashTreeRoot_v64_s21000(b *testing.B)   { benchStateHashTreeRoot(b, 64, 21000) }
+func BenchmarkStateHashTreeRoot_v512_s21000(b *testing.B)  { benchStateHashTreeRoot(b, 512, 21000) }
+func BenchmarkStateHashTreeRoot_v512_s100000(b *testing.B) { benchStateHashTreeRoot(b, 512, 100000) }
+
+// benchVerifyStateRoot exercises the exact call block import makes, so the
+// benchmark tracks the real hot path rather than hash_tree_root in isolation.
+func benchVerifyStateRoot(b *testing.B, numValidators, historyLen int) {
+	state := syntheticState(numValidators, historyLen)
+	root, err := state.HashTreeRoot()
+	if err != nil {
+		b.Fatalf("hash_tree_root: %v", err)
+	}
+	block := &types.Block{Slot: state.Slot + 1, StateRoot: root}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := VerifyStateRoot(state, block); err != nil {
+			b.Fatalf("verify state root: %v", err)
+		}
+	}
+}
+
+func BenchmarkVerifyStateRoot_v512_s21000(b *testing.B) { benchVerifyStateRoot(b, 512, 21000) }

--- a/internal/store/gossip.go
+++ b/internal/store/gossip.go
@@ -109,6 +109,26 @@ func (m *AttestationSignatureMap) Len() int {
 	return len(m.data)
 }
 
+// MaxAttestationBacklogSlots bounds how many slots of pending attestation
+// signatures are kept behind the head. Signatures are otherwise pruned only
+// below finalized, so a stalled finalization lets the backlog grow without
+// bound — inflating each aggregation session and feeding the stall. Beyond this
+// window (relative to head) the votes are too old to justify a still-unfinalized
+// checkpoint, so dropping them bounds memory and session size while leaving
+// normal operation untouched: finality lag is single- to low-double-digit slots,
+// far inside the window.
+const MaxAttestationBacklogSlots = 512
+
+// PruneBacklog drops pending signatures for slots more than
+// MaxAttestationBacklogSlots behind headSlot, bounding the backlog when
+// finalization has stalled. Returns the number of data roots removed.
+func (m *AttestationSignatureMap) PruneBacklog(headSlot uint64) int {
+	if headSlot <= MaxAttestationBacklogSlots {
+		return 0
+	}
+	return m.PruneBelow(headSlot - MaxAttestationBacklogSlots)
+}
+
 // SignatureCountForSlot is the number of collected votes whose attestation data
 // is for the given slot. Early aggregation gauges coverage of the slot being
 // proved, not the cross-slot backlog still awaiting pruning.

--- a/internal/store/gossip.go
+++ b/internal/store/gossip.go
@@ -109,6 +109,21 @@ func (m *AttestationSignatureMap) Len() int {
 	return len(m.data)
 }
 
+// SignatureCountForSlot is the number of collected votes whose attestation data
+// is for the given slot. Early aggregation gauges coverage of the slot being
+// proved, not the cross-slot backlog still awaiting pruning.
+func (m *AttestationSignatureMap) SignatureCountForSlot(slot uint64) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := 0
+	for _, entry := range m.data {
+		if entry.Data != nil && entry.Data.Slot == slot {
+			n += len(entry.Signatures)
+		}
+	}
+	return n
+}
+
 func (m *AttestationSignatureMap) Snapshot() map[[32]byte]*AttestationDataEntry {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/store/gossip.go
+++ b/internal/store/gossip.go
@@ -109,26 +109,6 @@ func (m *AttestationSignatureMap) Len() int {
 	return len(m.data)
 }
 
-// MaxAttestationBacklogSlots bounds how many slots of pending attestation
-// signatures are kept behind the head. Signatures are otherwise pruned only
-// below finalized, so a stalled finalization lets the backlog grow without
-// bound — inflating each aggregation session and feeding the stall. Beyond this
-// window (relative to head) the votes are too old to justify a still-unfinalized
-// checkpoint, so dropping them bounds memory and session size while leaving
-// normal operation untouched: finality lag is single- to low-double-digit slots,
-// far inside the window.
-const MaxAttestationBacklogSlots = 512
-
-// PruneBacklog drops pending signatures for slots more than
-// MaxAttestationBacklogSlots behind headSlot, bounding the backlog when
-// finalization has stalled. Returns the number of data roots removed.
-func (m *AttestationSignatureMap) PruneBacklog(headSlot uint64) int {
-	if headSlot <= MaxAttestationBacklogSlots {
-		return 0
-	}
-	return m.PruneBelow(headSlot - MaxAttestationBacklogSlots)
-}
-
 // SignatureCountForSlot is the number of collected votes whose attestation data
 // is for the given slot. Early aggregation gauges coverage of the slot being
 // proved, not the cross-slot backlog still awaiting pruning.

--- a/internal/store/gossip.go
+++ b/internal/store/gossip.go
@@ -2,16 +2,18 @@ package store
 
 import (
 	"sync"
-	"unsafe"
 
 	"github.com/geanlabs/gean/internal/types"
-	"github.com/geanlabs/gean/xmss"
 )
 
+// AttestationSignatureEntry holds only the serialized signature, never a parsed
+// XMSS handle. The aggregation worker runs asynchronously on a snapshot of this
+// map, so a handle cached here could be freed by a prune while the worker still
+// held the snapshot's copy of the pointer — a use-after-free that segfaulted the
+// prover. The worker parses its own handle from these bytes and owns its lifetime.
 type AttestationSignatureEntry struct {
 	ValidatorID uint64
 	Signature   [types.SignatureSize]byte
-	SigHandle   unsafe.Pointer
 }
 
 type AttestationDataEntry struct {
@@ -29,10 +31,6 @@ func NewAttestationSignatureMap() AttestationSignatureMap {
 }
 
 func (m *AttestationSignatureMap) Insert(dataRoot [32]byte, data *types.AttestationData, validatorID uint64, sig [types.SignatureSize]byte) {
-	m.InsertWithHandle(dataRoot, data, validatorID, sig, nil, nil)
-}
-
-func (m *AttestationSignatureMap) InsertWithHandle(dataRoot [32]byte, data *types.AttestationData, validatorID uint64, sig [types.SignatureSize]byte, handle unsafe.Pointer, parseErr error) {
 	if data == nil {
 		return
 	}
@@ -47,14 +45,9 @@ func (m *AttestationSignatureMap) InsertWithHandle(dataRoot [32]byte, data *type
 		entry = &AttestationDataEntry{Data: copyAttestationData(data)}
 		m.data[dataRoot] = entry
 	}
-	var h unsafe.Pointer
-	if parseErr == nil {
-		h = handle
-	}
 	entry.Signatures = append(entry.Signatures, AttestationSignatureEntry{
 		ValidatorID: validatorID,
 		Signature:   sig,
-		SigHandle:   h,
 	})
 }
 
@@ -68,11 +61,7 @@ func (m *AttestationSignatureMap) Delete(keys []AttestationDeleteKey) {
 		}
 		filtered := entry.Signatures[:0]
 		for _, sig := range entry.Signatures {
-			if sig.ValidatorID == key.ValidatorID {
-				if sig.SigHandle != nil {
-					xmss.FreeSignature(sig.SigHandle)
-				}
-			} else {
+			if sig.ValidatorID != key.ValidatorID {
 				filtered = append(filtered, sig)
 			}
 		}
@@ -89,13 +78,6 @@ func (m *AttestationSignatureMap) PruneBelow(finalizedSlot uint64) int {
 	pruned := 0
 	for root, entry := range m.data {
 		if entry == nil || entry.Data == nil || entry.Data.Slot <= finalizedSlot {
-			if entry != nil {
-				for _, sig := range entry.Signatures {
-					if sig.SigHandle != nil {
-						xmss.FreeSignature(sig.SigHandle)
-					}
-				}
-			}
 			delete(m.data, root)
 			pruned++
 		}

--- a/internal/store/gossip_test.go
+++ b/internal/store/gossip_test.go
@@ -60,46 +60,6 @@ func TestAttestationSignatureCountForSlot(t *testing.T) {
 	}
 }
 
-func TestAttestationSignaturePruneBacklog(t *testing.T) {
-	gsm := store.NewAttestationSignatureMap()
-	var sig [types.SignatureSize]byte
-
-	// Below the window relative to head, nothing is pruned (normal operation:
-	// finality lag is far inside the window).
-	head := uint64(100)
-	gsm.Insert([32]byte{1}, &types.AttestationData{Slot: head - 5}, 0, sig)
-	gsm.Insert([32]byte{2}, &types.AttestationData{Slot: head}, 1, sig)
-	if pruned := gsm.PruneBacklog(head); pruned != 0 {
-		t.Fatalf("in-window prune=%d, want 0", pruned)
-	}
-	if gsm.Len() != 2 {
-		t.Fatalf("in-window Len=%d, want 2", gsm.Len())
-	}
-
-	// With head far ahead, roots older than head-window are dropped, recent kept.
-	head = store.MaxAttestationBacklogSlots + 1000
-	floor := head - store.MaxAttestationBacklogSlots
-	gsm.Insert([32]byte{3}, &types.AttestationData{Slot: floor - 1}, 2, sig) // stale, drop
-	gsm.Insert([32]byte{4}, &types.AttestationData{Slot: floor + 1}, 3, sig) // recent, keep
-	pruned := gsm.PruneBacklog(head)
-	// The two slot-100-era roots and the stale root are all below the new floor.
-	if pruned != 3 {
-		t.Fatalf("backlog prune=%d, want 3", pruned)
-	}
-	snap := gsm.Snapshot()
-	if _, ok := snap[[32]byte{4}]; !ok {
-		t.Fatal("recent root was pruned")
-	}
-	if gsm.Len() != 1 {
-		t.Fatalf("post-prune Len=%d, want 1", gsm.Len())
-	}
-
-	// Head below the window never underflows / prunes.
-	if pruned := gsm.PruneBacklog(store.MaxAttestationBacklogSlots - 1); pruned != 0 {
-		t.Fatalf("head-below-window prune=%d, want 0", pruned)
-	}
-}
-
 func TestAttestationSignaturePruneBelow(t *testing.T) {
 	gsm := store.NewAttestationSignatureMap()
 	var sig [types.SignatureSize]byte

--- a/internal/store/gossip_test.go
+++ b/internal/store/gossip_test.go
@@ -32,6 +32,34 @@ func TestAttestationSignatureInsertAndDelete(t *testing.T) {
 	}
 }
 
+func TestAttestationSignatureCountForSlot(t *testing.T) {
+	gsm := store.NewAttestationSignatureMap()
+	var sig [types.SignatureSize]byte
+
+	if gsm.SignatureCountForSlot(1) != 0 {
+		t.Fatalf("empty map count=%d, want 0", gsm.SignatureCountForSlot(1))
+	}
+
+	// Slot 1: three votes on one root, one on another → 4. Slot 2: one vote.
+	// The count must be scoped to the queried slot, never the cross-slot total.
+	dr1, dr2, dr3 := [32]byte{1}, [32]byte{2}, [32]byte{3}
+	gsm.Insert(dr1, &types.AttestationData{Slot: 1}, 0, sig)
+	gsm.Insert(dr1, &types.AttestationData{Slot: 1}, 1, sig)
+	gsm.Insert(dr1, &types.AttestationData{Slot: 1}, 2, sig)
+	gsm.Insert(dr2, &types.AttestationData{Slot: 1}, 3, sig)
+	gsm.Insert(dr3, &types.AttestationData{Slot: 2}, 4, sig)
+
+	if got := gsm.SignatureCountForSlot(1); got != 4 {
+		t.Fatalf("SignatureCountForSlot(1)=%d, want 4", got)
+	}
+	if got := gsm.SignatureCountForSlot(2); got != 1 {
+		t.Fatalf("SignatureCountForSlot(2)=%d, want 1", got)
+	}
+	if got := gsm.SignatureCountForSlot(3); got != 0 {
+		t.Fatalf("SignatureCountForSlot(3)=%d, want 0", got)
+	}
+}
+
 func TestAttestationSignaturePruneBelow(t *testing.T) {
 	gsm := store.NewAttestationSignatureMap()
 	var sig [types.SignatureSize]byte

--- a/internal/store/gossip_test.go
+++ b/internal/store/gossip_test.go
@@ -60,6 +60,46 @@ func TestAttestationSignatureCountForSlot(t *testing.T) {
 	}
 }
 
+func TestAttestationSignaturePruneBacklog(t *testing.T) {
+	gsm := store.NewAttestationSignatureMap()
+	var sig [types.SignatureSize]byte
+
+	// Below the window relative to head, nothing is pruned (normal operation:
+	// finality lag is far inside the window).
+	head := uint64(100)
+	gsm.Insert([32]byte{1}, &types.AttestationData{Slot: head - 5}, 0, sig)
+	gsm.Insert([32]byte{2}, &types.AttestationData{Slot: head}, 1, sig)
+	if pruned := gsm.PruneBacklog(head); pruned != 0 {
+		t.Fatalf("in-window prune=%d, want 0", pruned)
+	}
+	if gsm.Len() != 2 {
+		t.Fatalf("in-window Len=%d, want 2", gsm.Len())
+	}
+
+	// With head far ahead, roots older than head-window are dropped, recent kept.
+	head = store.MaxAttestationBacklogSlots + 1000
+	floor := head - store.MaxAttestationBacklogSlots
+	gsm.Insert([32]byte{3}, &types.AttestationData{Slot: floor - 1}, 2, sig) // stale, drop
+	gsm.Insert([32]byte{4}, &types.AttestationData{Slot: floor + 1}, 3, sig) // recent, keep
+	pruned := gsm.PruneBacklog(head)
+	// The two slot-100-era roots and the stale root are all below the new floor.
+	if pruned != 3 {
+		t.Fatalf("backlog prune=%d, want 3", pruned)
+	}
+	snap := gsm.Snapshot()
+	if _, ok := snap[[32]byte{4}]; !ok {
+		t.Fatal("recent root was pruned")
+	}
+	if gsm.Len() != 1 {
+		t.Fatalf("post-prune Len=%d, want 1", gsm.Len())
+	}
+
+	// Head below the window never underflows / prunes.
+	if pruned := gsm.PruneBacklog(store.MaxAttestationBacklogSlots - 1); pruned != 0 {
+		t.Fatalf("head-below-window prune=%d, want 0", pruned)
+	}
+}
+
 func TestAttestationSignaturePruneBelow(t *testing.T) {
 	gsm := store.NewAttestationSignatureMap()
 	var sig [types.SignatureSize]byte

--- a/internal/syncer/backfill.go
+++ b/internal/syncer/backfill.go
@@ -26,6 +26,12 @@ func (sd *SyncDriver) checkAndBackfill(ctx context.Context, peerID libp2ppeer.ID
 	defer sd.release(peerID)
 
 	startSlot := sd.store.HeadSlot() + 1
+	if sd.marooned(peerStatus) {
+		// Reconciliation: start below the fork point (our finalized slot) so the
+		// range covers the divergence and fork choice can switch onto the peer's
+		// canonical chain. Starting at our head would only re-fetch our own tip.
+		startSlot = sd.store.LatestFinalized().Slot + 1
+	}
 	for startSlot <= peerStatus.HeadSlot {
 		if err := ctx.Err(); err != nil {
 			return
@@ -58,8 +64,26 @@ func (sd *SyncDriver) shouldBackfill(peerStatus *p2p.StatusMessage) bool {
 		return false
 	}
 	ourHead := sd.store.HeadSlot()
-	return peerStatus.HeadSlot > ourHead &&
-		peerStatus.HeadSlot-ourHead > blocksByRangeSyncThreshold
+	if peerStatus.HeadSlot > ourHead && peerStatus.HeadSlot-ourHead > blocksByRangeSyncThreshold {
+		return true
+	}
+	return sd.marooned(peerStatus)
+}
+
+// marooned reports whether our finalized checkpoint has fallen well behind the
+// peer's while our head kept pace — the signature of a node stuck on its own
+// fork. By-root parent fetches cannot recover a fork the peer never had (the peer
+// answers "no blocks" for a root only our branch produced), so this triggers a
+// range backfill from our finalized point to let fork choice reconcile.
+func (sd *SyncDriver) marooned(peerStatus *p2p.StatusMessage) bool {
+	if sd == nil || sd.store == nil || peerStatus == nil {
+		return false
+	}
+	finalized := sd.store.LatestFinalized()
+	if finalized == nil {
+		return false
+	}
+	return peerStatus.FinalizedSlot > finalized.Slot+forkReconcileFinalizedThreshold
 }
 
 func requestCount(startSlot, headSlot uint64) uint64 {

--- a/internal/syncer/backfill_test.go
+++ b/internal/syncer/backfill_test.go
@@ -308,3 +308,24 @@ func TestSyncDriver_CheckAndBackfill_CancelAbortsStalledDelivery(t *testing.T) {
 		t.Errorf("expected no further range fetches after aborted delivery, got %d calls", got)
 	}
 }
+
+func TestSyncDriver_ShouldBackfill_MaroonedOnFork(t *testing.T) {
+	n, st := makeTestSyncHarness()
+	// Our head kept pace at slot 100, but finalized is stuck at genesis: the
+	// marooned-on-own-fork signature that by-root fetches cannot recover.
+	head := &types.BlockHeader{Slot: 100}
+	root := mustHeaderRoot(head)
+	st.SetHead(root)
+	st.InsertBlockHeader(root, head)
+	st.SetLatestFinalized(&types.Checkpoint{Slot: 0})
+	sd := NewSyncDriver(context.Background(), n, st, &mockSyncP2P{})
+
+	// Peer at the same head but finalized far ahead -> reconcile.
+	if !sd.shouldBackfill(&p2p.StatusMessage{HeadSlot: 100, FinalizedSlot: forkReconcileFinalizedThreshold + 1}) {
+		t.Fatal("expected backfill when finalized is stuck behind a peer at equal head")
+	}
+	// Peer finalized only marginally ahead -> normal skew, no reconcile.
+	if sd.shouldBackfill(&p2p.StatusMessage{HeadSlot: 100, FinalizedSlot: forkReconcileFinalizedThreshold - 1}) {
+		t.Fatal("did not expect backfill for small finalized skew at equal head")
+	}
+}

--- a/internal/syncer/config.go
+++ b/internal/syncer/config.go
@@ -6,4 +6,10 @@ const (
 	blocksByRangeSyncThreshold = 2
 	pollInterval               = 32 * time.Second
 	peerStatusTimeout          = 10 * time.Second
+
+	// forkReconcileFinalizedThreshold is how far our finalized checkpoint may
+	// fall behind a peer's before we treat it as a fork we are marooned on and
+	// range-backfill to reconcile. Cross-node finalized skew is normally 0-2
+	// slots on a shared chain, so this stays clear of healthy operation.
+	forkReconcileFinalizedThreshold = 8
 )

--- a/xmss/concurrency_stress_test.go
+++ b/xmss/concurrency_stress_test.go
@@ -1,0 +1,178 @@
+package xmss
+
+import (
+	"fmt"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/geanlabs/gean/internal/types"
+)
+
+// prepareStressInputs generates numSigs keypairs, signs one message with each,
+// and returns the serialized public keys and signatures. Handles are parsed
+// per-call in the workers so concurrent aggregations never share a handle —
+// the realistic model for parallel group proving, where each group owns its
+// signatures.
+func prepareStressInputs(t *testing.T, numSigs int) ([][types.PubkeySize]byte, [][types.SignatureSize]byte, [32]byte) {
+	t.Helper()
+	var message [32]byte
+	message[0] = 0x7a
+	pkList := make([][types.PubkeySize]byte, numSigs)
+	sigList := make([][types.SignatureSize]byte, numSigs)
+	for i := range numSigs {
+		kp, err := GenerateKeyPair(fmt.Sprintf("stress-%d", i), 0, 1<<16)
+		if err != nil {
+			t.Fatalf("keygen %d: %v", i, err)
+		}
+		sig, err := kp.Sign(0, message)
+		if err != nil {
+			kp.Close()
+			t.Fatalf("sign %d: %v", i, err)
+		}
+		pk, err := kp.PublicKeyBytes()
+		kp.Close()
+		if err != nil {
+			t.Fatalf("pubkey %d: %v", i, err)
+		}
+		pkList[i] = pk
+		sigList[i] = sig
+	}
+	return pkList, sigList, message
+}
+
+// aggregateFresh parses its own handles, aggregates, frees them, and returns the
+// proof. Distinct handles per call isolate prover reentrancy from handle sharing.
+func aggregateFresh(pkList [][types.PubkeySize]byte, sigList [][types.SignatureSize]byte, message [32]byte) ([]byte, error) {
+	n := len(pkList)
+	pks := make([]CPubKey, 0, n)
+	sigs := make([]CSig, 0, n)
+	defer func() {
+		for _, p := range pks {
+			FreePublicKey(p)
+		}
+		for _, s := range sigs {
+			FreeSignature(s)
+		}
+	}()
+	for i := range n {
+		cpk, err := ParsePublicKey(pkList[i])
+		if err != nil {
+			return nil, err
+		}
+		pks = append(pks, cpk)
+		csig, err := ParseSignature(sigList[i][:])
+		if err != nil {
+			return nil, err
+		}
+		sigs = append(sigs, csig)
+	}
+	return AggregateSignatures(pks, sigs, message, 0)
+}
+
+func maxRSSBytes() int64 {
+	var ru syscall.Rusage
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &ru); err != nil {
+		return 0
+	}
+	// darwin reports bytes, linux reports kilobytes.
+	return int64(ru.Maxrss)
+}
+
+// TestFFIConcurrentAggregation answers whether parallel group proving is viable:
+// is the aggregate FFI reentrant (no crash, all proofs valid) and does the prover
+// leave idle cores (so concurrency would raise throughput)? It bypasses the
+// proving gate exactly as parallel proving would.
+func TestFFIConcurrentAggregation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow FFI proving stress test in -short")
+	}
+	const numSigs = 8
+	const proofs = 6
+	const parallelism = 4
+
+	pkList, sigList, message := prepareStressInputs(t, numSigs)
+	EnsureProverReady()
+	EnsureVerifierReady()
+
+	// Warm one proof so the comparison excludes any first-call lazy init.
+	if _, err := aggregateFresh(pkList, sigList, message); err != nil {
+		t.Fatalf("warmup aggregate: %v", err)
+	}
+
+	verify := func(proof []byte) error {
+		pks := make([]CPubKey, 0, numSigs)
+		defer func() {
+			for _, p := range pks {
+				FreePublicKey(p)
+			}
+		}()
+		for i := range numSigs {
+			cpk, err := ParsePublicKey(pkList[i])
+			if err != nil {
+				return err
+			}
+			pks = append(pks, cpk)
+		}
+		return VerifyAggregatedSignature(proof, pks, message, 0)
+	}
+
+	rssBefore := maxRSSBytes()
+
+	// Serial baseline.
+	serialStart := time.Now()
+	for i := range proofs {
+		proof, err := aggregateFresh(pkList, sigList, message)
+		if err != nil {
+			t.Fatalf("serial aggregate %d: %v", i, err)
+		}
+		if err := verify(proof); err != nil {
+			t.Fatalf("serial proof %d invalid: %v", i, err)
+		}
+	}
+	serialDur := time.Since(serialStart)
+
+	// Parallel: same number of proofs across `parallelism` goroutines, distinct
+	// handles each. A crash here means the FFI is not reentrant; an invalid proof
+	// means it is not correct under concurrency.
+	rssMidRSS := maxRSSBytes()
+	var wg sync.WaitGroup
+	errCh := make(chan error, proofs)
+	sem := make(chan struct{}, parallelism)
+	parStart := time.Now()
+	for i := range proofs {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(idx int) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			proof, err := aggregateFresh(pkList, sigList, message)
+			if err != nil {
+				errCh <- fmt.Errorf("parallel aggregate %d: %w", idx, err)
+				return
+			}
+			if err := verify(proof); err != nil {
+				errCh <- fmt.Errorf("parallel proof %d invalid: %w", idx, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	parDur := time.Since(parStart)
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("concurrency failure: %v", err)
+		}
+	}
+
+	rssAfter := maxRSSBytes()
+	speedup := serialDur.Seconds() / parDur.Seconds()
+
+	t.Logf("FFI concurrency: %d sigs/proof, %d proofs, parallelism=%d", numSigs, proofs, parallelism)
+	t.Logf("  serial   total=%v  per-proof=%v", serialDur, serialDur/proofs)
+	t.Logf("  parallel total=%v  per-proof=%v", parDur, parDur/proofs)
+	t.Logf("  speedup (serial/parallel) = %.2fx  (≈%d ⇒ prover single-threaded, ≈1 ⇒ already core-saturated)", speedup, parallelism)
+	t.Logf("  maxRSS: before=%dMB midSerial=%dMB after=%dMB (darwin bytes / linux KB)",
+		rssBefore>>20, rssMidRSS>>20, rssAfter>>20)
+}

--- a/xmss/rust/Cargo.lock
+++ b/xmss/rust/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
  "derive_more",
  "foldhash 0.2.0",
  "hashbrown 0.17.1",
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "k256",
  "keccak-asm",
@@ -47,6 +47,15 @@ checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
 dependencies = [
  "arrayvec",
  "bytes",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -173,6 +182,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "educe",
+ "num-bigint",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +223,16 @@ name = "ark-ff-asm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -241,6 +277,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +323,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "num-bigint",
+ "serde_with",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ark-std"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +371,16 @@ name = "ark-std"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
@@ -359,6 +442,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -443,6 +532,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "byte-slice-cast"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +600,18 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
 ]
 
 [[package]]
@@ -608,6 +724,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +840,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +913,12 @@ dependencies = [
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -991,6 +1128,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures-core"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+
+[[package]]
+name = "futures-util"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,6 +1218,12 @@ checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1151,6 +1318,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +1384,17 @@ checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
 dependencies = [
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1245,6 +1447,17 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "k256"
@@ -1644,6 +1857,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,6 +2220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,6 +2475,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2288,14 +2533,15 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.18.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
@@ -2379,6 +2625,30 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2489,6 +2759,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.2",
+ "serde_core",
+ "serde_json",
+ "time",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2566,6 +2855,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -2665,6 +2960,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "system-info"
 version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
@@ -2685,7 +2991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -2721,6 +3027,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2735,7 +3086,7 @@ version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -2951,6 +3302,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2967,7 +3363,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -2980,7 +3376,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver 1.0.28",
 ]
 
@@ -3007,10 +3403,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -3064,7 +3513,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -3095,7 +3544,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -3114,7 +3563,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver 1.0.28",
  "serde",

--- a/xmss/rust/Cargo.toml
+++ b/xmss/rust/Cargo.toml
@@ -13,9 +13,11 @@ strip = "symbols"
 codegen-units = 16
 
 # Optimized profile used by `make ffi` / Dockerfile. Inherits release, enables
-# thin LTO and a single codegen unit for whole-program optimization across the
+# fat LTO and a single codegen unit for whole-program optimization across the
 # leanMultisig backend hot path. Matches zeam's `[profile.multisig-release]`
 # which delivers ~300 ms committee aggregation vs gean's ~2 s on plain release.
+# Fat (vs thin) LTO inlines across the whole prover/verifier graph — a further
+# cut in the signature-verify CPU that dominates block-import at scale.
 #
 # Keep opt-level at the inherited `3`. Do NOT switch to `opt-level = "z"` or
 # `"s"` here: combined with `codegen-units = 1` they deterministically
@@ -25,5 +27,5 @@ codegen-units = 16
 # leanEthereum/leanMultisig#198 and blockblaz/zeam#734.
 [profile.multisig-release]
 inherits = "release"
-lto = "thin"
+lto = "fat"
 codegen-units = 1


### PR DESCRIPTION
Performance and resilience work for block import at scale, motivated by a ~23-hour, 21k-slot single-node run whose head held a steady 4s/slot but whose finality collapsed (finalized froze ~3,000 slots behind head).

## Changes

**`fix(syncer): range-backfill to reconcile when marooned on our own fork`**
The finality freeze root cause: a node forked from its peer keeps re-requesting a parent *by root* the peer never had (hundreds of "peer returned no blocks"), and `shouldBackfill` only triggered range backfill when the peer's *head* was ahead — which it wasn't (heads equal, only *finalized* diverged). Now a range backfill also fires when the peer's finalized checkpoint is well ahead of ours (threshold 8, vs 0–2 slot skew in healthy operation), starting from our finalized slot so it crosses the divergence and fork choice can switch onto the peer's canonical chain. Covered by a new unit test.

**`perf(ffi): switch multisig-release to fat LTO`**
The same run showed the aggregation worker hitting its proving budget ~99× (dropping aggregates) once load grew. That is a proving-*speed* problem, not a scheduling one — gean already time-bounds aggregation and completes it before the next-slot proposal. Fat (vs thin) LTO inlines across the whole prover/verifier graph, trimming the signature-verify CPU. opt-level stays 3, so the documented z/s + codegen-units=1 miscompile guard is unaffected; FFI tests pass unchanged.

**`test(statetransition): add state hash-tree-root scale benchmark`**
Isolates the dominant slot-growing term in import: `VerifyStateRoot` re-merkleizes the whole state per block, and its history arrays grow one entry per slot. The benchmark (pure Go, no FFI, no devnet) grids validator count against slot history and shows the cost is slot-dominated (~0.13ms at 1k slots to ~8.6ms at 100k). `docs/block-import-perf.md` records the finding and scopes cached tree hashing as the consensus-critical follow-up (state root must stay bit-for-bit identical).

## Verification
`make build`, `make ffi`, `make test-ffi`, `make test` (25 packages), `make lint` all pass. No consensus-logic, types, constants, or spec-pin changes.