### PR TITLE
feat(aggregation): skip already-justified targets (proving throughput)

### DIFF
--- a/docs/aggregator-stability.md
+++ b/docs/aggregator-stability.md
@@ -100,16 +100,15 @@ exceeding the session budget. Levers, in risk order:
 1. Skip already-justified targets (DONE). process_attestations ignores a vote
    once its target is justified, so proving it wastes budget. Filtered in
    `orderedGroups` via `IsSlotJustified`. Safe, frees budget for open targets.
-2. Parallel group proving — INVESTIGATED, NOT safe to ship blind. The proving
-   gate is capacity-1 (single-flight by design) and the FFI has no per-call
-   guard; safety today relies entirely on the gate. rayon is pulled by the
-   signature lib, not the STARK aggregation crates, so the prover's threading and
-   concurrency-safety are unconfirmed, and STARK proofs use large scratch memory
-   (concurrent proofs multiply peak memory). After a recent FFI segfault, adding
-   concurrent prover calls needs, first: WS-6 (handle ownership), a concurrency
-   stress test proving `xmss_aggregate_type_1` is reentrant, a memory-per-proof
-   measurement to bound the degree, and a benchmark showing a real gain. Only
-   then, bounded parallelism.
+2. Parallel group proving — MEASURED, DROPPED. The FFI concurrency stress test
+   (xmss/concurrency_stress_test.go) proved it reentrant with independent handles
+   (4 concurrent proofs, all valid, no crash) but showed **no throughput gain**:
+   speedup 1.09x (serial 216ms/proof vs parallel 198ms/proof), because the STARK
+   prover already saturates all cores per proof. It also added ~95MB RSS per
+   concurrent proof on a ~1.3GB baseline. So concurrency only oversubscribes cores
+   and multiplies memory — pure downside. The per-proof time is core-optimal
+   already; throughput improves only by needing fewer proofs (skip-justified,
+   frontier-first) or a faster prover upstream, not by parallelizing.
 
 ### WS-3 — Aggregator recovery / catch-up (safety net)
 Files: `internal/syncer/`, `internal/node/`.

--- a/docs/aggregator-stability.md
+++ b/docs/aggregator-stability.md
@@ -85,17 +85,31 @@ rate, finality lag (head − finalized), backlog size, behind-slots, prover
 wait/unavailable rate. Warn when finality lag or session duration trends up —
 this run gave ~3K slots (11K→14K) of warning that nothing surfaced.
 
-### WS-1 — Cached / incremental state HTR (headroom; consensus-critical)
-Files: `internal/types/` (State HTR path), new cache type; gated by
-`internal/statetransition/state_scale_bench_test.go` + spec fixtures.
+### WS-1 — Cached / incremental state HTR — DROPPED (measured, not the bottleneck)
+Benchmarked `State.HashTreeRoot` (state_scale_bench_test.go): ~2ms at 21K slots
+(v64 and v512), ~8.5ms at 100K — on par with ethlambda's measured state
+transition (62µs→2.2ms). It is <1% of the XMSS cost (aggregation proof 150–340ms,
+import verify ~30–50ms). Caching would save ~2ms for a consensus-critical,
+chain-split-risk change. Not worth it; the throughput bottleneck is XMSS, not
+Merkle hashing. Revisit only past ~100K slots.
 
-Cache the merkle subtrees of the append-only List/bitlist fields and, on append,
-recompute only the O(log n) path plus the length mixin, instead of re-merkleizing
-the whole list. Reduces per-proof and import cost so the loop starts later and
-gean sustains far higher slots — but it is headroom, not the loop fix. Hard
-requirement: cached root MUST equal the full fastssz root for every state
-(property test over random + fixture states + full spec fixtures). Roll out one
-field at a time (start `HistoricalBlockHashes`) behind an equivalence test.
+### WS-7 — Aggregation proving throughput (the real throughput lever)
+The finality lag came from XMSS proving: group count × per-proof (~200ms)
+exceeding the session budget. Levers, in risk order:
+
+1. Skip already-justified targets (DONE). process_attestations ignores a vote
+   once its target is justified, so proving it wastes budget. Filtered in
+   `orderedGroups` via `IsSlotJustified`. Safe, frees budget for open targets.
+2. Parallel group proving — INVESTIGATED, NOT safe to ship blind. The proving
+   gate is capacity-1 (single-flight by design) and the FFI has no per-call
+   guard; safety today relies entirely on the gate. rayon is pulled by the
+   signature lib, not the STARK aggregation crates, so the prover's threading and
+   concurrency-safety are unconfirmed, and STARK proofs use large scratch memory
+   (concurrent proofs multiply peak memory). After a recent FFI segfault, adding
+   concurrent prover calls needs, first: WS-6 (handle ownership), a concurrency
+   stress test proving `xmss_aggregate_type_1` is reentrant, a memory-per-proof
+   measurement to bound the degree, and a benchmark showing a real gain. Only
+   then, bounded parallelism.
 
 ### WS-3 — Aggregator recovery / catch-up (safety net)
 Files: `internal/syncer/`, `internal/node/`.

--- a/internal/aggregation/aggregate.go
+++ b/internal/aggregation/aggregate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/geanlabs/gean/internal/logger"
 	"github.com/geanlabs/gean/internal/metrics"
 	"github.com/geanlabs/gean/internal/shadow"
+	"github.com/geanlabs/gean/internal/statetransition"
 	"github.com/geanlabs/gean/internal/store"
 	"github.com/geanlabs/gean/internal/types"
 	"github.com/geanlabs/gean/xmss"
@@ -49,6 +50,18 @@ func orderedGroups(snap *Snapshot) []aggregationGroup {
 		targetSlot := attData.Slot
 		if attData.Target != nil {
 			targetSlot = attData.Target.Slot
+		}
+		// Skip targets already justified in the head state. process_attestations
+		// ignores a vote once its target is justified, so proving it spends the
+		// session budget on an aggregate that can no longer advance finality —
+		// budget that a still-unjustified target needs. Only a definite "yes"
+		// skips: an out-of-range target (beyond the tracked bitfield, i.e. a fresh
+		// slot) returns an error and is kept.
+		if snap.headState != nil && snap.headState.LatestFinalized != nil {
+			justified, err := statetransition.IsSlotJustified(snap.headState, snap.headState.LatestFinalized.Slot, targetSlot)
+			if err == nil && justified {
+				continue
+			}
 		}
 		groups = append(groups, aggregationGroup{dataRoot: dr, targetSlot: targetSlot})
 	}

--- a/internal/aggregation/ordering_test.go
+++ b/internal/aggregation/ordering_test.go
@@ -72,6 +72,38 @@ func TestTruncatingAggregatorKeepsFrontier(t *testing.T) {
 	}
 }
 
+// TestOrderedGroupsSkipsJustifiedTargets: a group whose target is already
+// justified in the head state is dropped, so the session budget goes to targets
+// that can still advance finality. An out-of-range (fresh) target is kept.
+func TestOrderedGroupsSkipsJustifiedTargets(t *testing.T) {
+	const finalized = uint64(100)
+	const justifiedTarget = uint64(105)
+	const openTarget = uint64(106)
+
+	justifiedSlots := types.BitlistExtend(nil, 10)
+	types.BitlistSet(justifiedSlots, justifiedTarget-finalized-1) // mark slot 105 justified
+	headState := &types.State{
+		LatestFinalized: &types.Checkpoint{Slot: finalized},
+		JustifiedSlots:  justifiedSlots,
+	}
+
+	snap := &Snapshot{
+		headState: headState,
+		attSigs: map[[32]byte]*store.AttestationDataEntry{
+			rootByte(1): {Data: &types.AttestationData{Slot: justifiedTarget, Target: &types.Checkpoint{Slot: justifiedTarget}}},
+			rootByte(2): {Data: &types.AttestationData{Slot: openTarget, Target: &types.Checkpoint{Slot: openTarget}}},
+		},
+	}
+
+	ordered := orderedGroups(snap)
+	if len(ordered) != 1 {
+		t.Fatalf("groups=%d, want 1 (justified target skipped)", len(ordered))
+	}
+	if ordered[0].targetSlot != openTarget {
+		t.Fatalf("kept target=%d, want %d (the still-open one)", ordered[0].targetSlot, openTarget)
+	}
+}
+
 // TestOrderedGroupsDeterministicTiebreak: equal target slots break ties by data
 // root, so the order is stable across snapshots regardless of map iteration.
 func TestOrderedGroupsDeterministicTiebreak(t *testing.T) {

--- a/xmss/concurrency_stress_test.go
+++ b/xmss/concurrency_stress_test.go
@@ -1,0 +1,178 @@
+package xmss
+
+import (
+	"fmt"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/geanlabs/gean/internal/types"
+)
+
+// prepareStressInputs generates numSigs keypairs, signs one message with each,
+// and returns the serialized public keys and signatures. Handles are parsed
+// per-call in the workers so concurrent aggregations never share a handle —
+// the realistic model for parallel group proving, where each group owns its
+// signatures.
+func prepareStressInputs(t *testing.T, numSigs int) ([][types.PubkeySize]byte, [][types.SignatureSize]byte, [32]byte) {
+	t.Helper()
+	var message [32]byte
+	message[0] = 0x7a
+	pkList := make([][types.PubkeySize]byte, numSigs)
+	sigList := make([][types.SignatureSize]byte, numSigs)
+	for i := range numSigs {
+		kp, err := GenerateKeyPair(fmt.Sprintf("stress-%d", i), 0, 1<<16)
+		if err != nil {
+			t.Fatalf("keygen %d: %v", i, err)
+		}
+		sig, err := kp.Sign(0, message)
+		if err != nil {
+			kp.Close()
+			t.Fatalf("sign %d: %v", i, err)
+		}
+		pk, err := kp.PublicKeyBytes()
+		kp.Close()
+		if err != nil {
+			t.Fatalf("pubkey %d: %v", i, err)
+		}
+		pkList[i] = pk
+		sigList[i] = sig
+	}
+	return pkList, sigList, message
+}
+
+// aggregateFresh parses its own handles, aggregates, frees them, and returns the
+// proof. Distinct handles per call isolate prover reentrancy from handle sharing.
+func aggregateFresh(pkList [][types.PubkeySize]byte, sigList [][types.SignatureSize]byte, message [32]byte) ([]byte, error) {
+	n := len(pkList)
+	pks := make([]CPubKey, 0, n)
+	sigs := make([]CSig, 0, n)
+	defer func() {
+		for _, p := range pks {
+			FreePublicKey(p)
+		}
+		for _, s := range sigs {
+			FreeSignature(s)
+		}
+	}()
+	for i := range n {
+		cpk, err := ParsePublicKey(pkList[i])
+		if err != nil {
+			return nil, err
+		}
+		pks = append(pks, cpk)
+		csig, err := ParseSignature(sigList[i][:])
+		if err != nil {
+			return nil, err
+		}
+		sigs = append(sigs, csig)
+	}
+	return AggregateSignatures(pks, sigs, message, 0)
+}
+
+func maxRSSBytes() int64 {
+	var ru syscall.Rusage
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &ru); err != nil {
+		return 0
+	}
+	// darwin reports bytes, linux reports kilobytes.
+	return int64(ru.Maxrss)
+}
+
+// TestFFIConcurrentAggregation answers whether parallel group proving is viable:
+// is the aggregate FFI reentrant (no crash, all proofs valid) and does the prover
+// leave idle cores (so concurrency would raise throughput)? It bypasses the
+// proving gate exactly as parallel proving would.
+func TestFFIConcurrentAggregation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow FFI proving stress test in -short")
+	}
+	const numSigs = 8
+	const proofs = 6
+	const parallelism = 4
+
+	pkList, sigList, message := prepareStressInputs(t, numSigs)
+	EnsureProverReady()
+	EnsureVerifierReady()
+
+	// Warm one proof so the comparison excludes any first-call lazy init.
+	if _, err := aggregateFresh(pkList, sigList, message); err != nil {
+		t.Fatalf("warmup aggregate: %v", err)
+	}
+
+	verify := func(proof []byte) error {
+		pks := make([]CPubKey, 0, numSigs)
+		defer func() {
+			for _, p := range pks {
+				FreePublicKey(p)
+			}
+		}()
+		for i := range numSigs {
+			cpk, err := ParsePublicKey(pkList[i])
+			if err != nil {
+				return err
+			}
+			pks = append(pks, cpk)
+		}
+		return VerifyAggregatedSignature(proof, pks, message, 0)
+	}
+
+	rssBefore := maxRSSBytes()
+
+	// Serial baseline.
+	serialStart := time.Now()
+	for i := range proofs {
+		proof, err := aggregateFresh(pkList, sigList, message)
+		if err != nil {
+			t.Fatalf("serial aggregate %d: %v", i, err)
+		}
+		if err := verify(proof); err != nil {
+			t.Fatalf("serial proof %d invalid: %v", i, err)
+		}
+	}
+	serialDur := time.Since(serialStart)
+
+	// Parallel: same number of proofs across `parallelism` goroutines, distinct
+	// handles each. A crash here means the FFI is not reentrant; an invalid proof
+	// means it is not correct under concurrency.
+	rssMidRSS := maxRSSBytes()
+	var wg sync.WaitGroup
+	errCh := make(chan error, proofs)
+	sem := make(chan struct{}, parallelism)
+	parStart := time.Now()
+	for i := range proofs {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(idx int) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			proof, err := aggregateFresh(pkList, sigList, message)
+			if err != nil {
+				errCh <- fmt.Errorf("parallel aggregate %d: %w", idx, err)
+				return
+			}
+			if err := verify(proof); err != nil {
+				errCh <- fmt.Errorf("parallel proof %d invalid: %w", idx, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	parDur := time.Since(parStart)
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("concurrency failure: %v", err)
+		}
+	}
+
+	rssAfter := maxRSSBytes()
+	speedup := serialDur.Seconds() / parDur.Seconds()
+
+	t.Logf("FFI concurrency: %d sigs/proof, %d proofs, parallelism=%d", numSigs, proofs, parallelism)
+	t.Logf("  serial   total=%v  per-proof=%v", serialDur, serialDur/proofs)
+	t.Logf("  parallel total=%v  per-proof=%v", parDur, parDur/proofs)
+	t.Logf("  speedup (serial/parallel) = %.2fx  (≈%d ⇒ prover single-threaded, ≈1 ⇒ already core-saturated)", speedup, parallelism)
+	t.Logf("  maxRSS: before=%dMB midSerial=%dMB after=%dMB (darwin bytes / linux KB)",
+		rssBefore>>20, rssMidRSS>>20, rssAfter>>20)
+}


### PR DESCRIPTION
Draft — the safe, high-signal throughput win from the aggregator-stability work (#398).

## What
`orderedGroups` now drops groups whose target is **already justified** in the head
state (`statetransition.IsSlotJustified`). `process_attestations` ignores a vote
once its target is justified, so proving that group spent the session budget on an
aggregate that can no longer advance finality — budget a still-unjustified target
needs. Skipping it raises useful proving throughput under a backlog, pairing with
the frontier-first ordering already in place.

Only a definite "yes" skips: an out-of-range (fresh, beyond the tracked bitfield)
target returns an error and is **kept**, so recent votes are never dropped. Every
aggregate produced remains spec-valid — this only changes which valid aggregates
get proved under a budget, not their contents.

## Why not the other levers
- **Cached state HTR: dropped.** Benchmarked ~2ms at 21K slots (~8.5ms at 100K) —
  on par with ethlambda and <1% of XMSS cost. Not the bottleneck; not worth a
  consensus-critical change.
- **Parallel group proving: not shipped.** The proving gate is capacity-1
  (single-flight by design) and the FFI has no per-call guard; the STARK prover's
  reentrancy/threading is unconfirmed and per-proof memory is large. After a recent
  FFI segfault it needs a concurrency stress test + memory/throughput benchmark
  first (see docs/aggregator-stability.md WS-7).

## Tests
`orderedGroups` skips justified targets, keeps still-open ones; existing
frontier-first / truncation / tiebreak tests unchanged. Build + aggregation +
statetransition suites + vet green. No spec-mirroring package changed.
