### PR TITLE
fix: keep the store clock current under load, and stop unanswerable range backfill

### DIFF
--- a/cmd/gean/network.go
+++ b/cmd/gean/network.go
@@ -60,10 +60,13 @@ func registerReqRespHandlers(p2pHost *p2p.Host, s *store.ConsensusStore) {
 		func(root [32]byte) *types.SignedBlock {
 			return s.GetSignedBlock(root)
 		},
+		// The block-request window slides with the responder's current slot, not its
+		// head: a lagging head would advertise a lower floor and offer history the
+		// spec lets us prune.
 		func() uint64 {
-			return s.HeadSlot()
+			return types.CurrentSlot(s.Config().GenesisTime, uint64(time.Now().UnixMilli()))
 		},
-		func(startSlot, count uint64) []*types.SignedBlock {
+		func(startSlot, count uint64) ([]*types.SignedBlock, bool) {
 			return s.GetCanonicalBlocksInRange(startSlot, count)
 		},
 	)

--- a/internal/node/dispatch.go
+++ b/internal/node/dispatch.go
@@ -23,9 +23,6 @@ func (e *Engine) dispatch(ctx context.Context, ticks <-chan time.Time) {
 		case block := <-e.BlockCh:
 			e.onBlock(block)
 
-		case agg := <-e.AggregationCh:
-			e.onGossipAggregatedAttestation(agg)
-
 		case result := <-e.ProposalResultCh:
 			e.acceptProposal(ctx, result)
 

--- a/internal/node/drain.go
+++ b/internal/node/drain.go
@@ -2,18 +2,28 @@ package node
 
 import "github.com/geanlabs/gean/internal/logger"
 
-func (e *Engine) drainPendingBlocks() {
+// drainPendingBlocks imports the blocks already queued when the drain starts and
+// no more. Sync delivery blocks on BlockCh, so a producer refills every slot the
+// drain frees: draining until the channel reads empty hands the tick loop an
+// unbounded amount of work, and store.OnTick has already run for this tick — the
+// store clock then sits stale for the whole drain and correctly-timed blocks are
+// rejected as beyond the future horizon. Whatever arrives mid-drain is picked up
+// by the dispatch loop or the next tick.
+func (e *Engine) drainPendingBlocks() int {
 	drained := 0
-	for {
+drain:
+	for remaining := len(e.BlockCh); remaining > 0; remaining-- {
 		select {
 		case block := <-e.BlockCh:
 			e.onBlock(block)
 			drained++
 		default:
-			if drained > 0 {
-				logger.Info(logger.Chain, "drained %d pending blocks before attestation", drained)
-			}
-			return
+			// The dispatch loop took part of the batch first; nothing left.
+			break drain
 		}
 	}
+	if drained > 0 {
+		logger.Info(logger.Chain, "drained %d pending blocks before attestation", drained)
+	}
+	return drained
 }

--- a/internal/node/drain_test.go
+++ b/internal/node/drain_test.go
@@ -1,0 +1,105 @@
+package node
+
+import (
+	"testing"
+	"time"
+
+	"github.com/geanlabs/gean/internal/types"
+)
+
+func blockAtSlot(slot uint64) *types.SignedBlock {
+	return &types.SignedBlock{Block: &types.Block{Slot: slot, Body: &types.BlockBody{}}}
+}
+
+// The drain must import only what was queued on entry. Sync delivery blocks on
+// BlockCh, so a producer refills every slot the drain frees; draining until the
+// channel reads empty hands the tick loop unbounded work, and the store clock —
+// already advanced for this tick — then sits stale for the whole drain, which is
+// what makes correctly-timed blocks fail the future-horizon check.
+//
+// The channel starts full with a producer blocked on it, so the depth at entry is
+// exactly the capacity no matter how the two goroutines interleave.
+func TestDrainPendingBlocks_ImportsOnlyTheQueueDepthOnEntry(t *testing.T) {
+	const capacity = 8
+
+	e := &Engine{
+		Store:   makeTestStore(),
+		BlockCh: make(chan *types.SignedBlock, capacity),
+	}
+	for i := 0; i < capacity; i++ {
+		e.BlockCh <- blockAtSlot(uint64(i))
+	}
+
+	stop := make(chan struct{})
+	producerDone := make(chan struct{})
+	go func() {
+		defer close(producerDone)
+		for {
+			select {
+			case <-stop:
+				return
+			case e.BlockCh <- blockAtSlot(999):
+			}
+		}
+	}()
+	defer func() {
+		close(stop)
+		<-producerDone
+	}()
+
+	type result struct{ drained int }
+	got := make(chan result, 1)
+	go func() { got <- result{e.drainPendingBlocks()} }()
+
+	select {
+	case r := <-got:
+		if r.drained != capacity {
+			t.Errorf("drained %d blocks, want %d (the depth at entry) — a refilling producer extended the drain",
+				r.drained, capacity)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("drainPendingBlocks never returned: a refilling producer extended it without bound")
+	}
+}
+
+func TestDrainPendingBlocks_EmptyChannelReturns(t *testing.T) {
+	e := &Engine{
+		Store:   makeTestStore(),
+		BlockCh: make(chan *types.SignedBlock, 4),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		if drained := e.drainPendingBlocks(); drained != 0 {
+			t.Errorf("drained %d blocks from an empty channel, want 0", drained)
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("drainPendingBlocks blocked on an empty channel")
+	}
+}
+
+// Bounding the drain must not leave admitted blocks stranded: with no concurrent
+// producer, everything queued on entry is imported.
+func TestDrainPendingBlocks_ConsumesEveryQueuedBlock(t *testing.T) {
+	e := &Engine{
+		Store:   makeTestStore(),
+		BlockCh: make(chan *types.SignedBlock, 16),
+	}
+
+	const queued = 8
+	for i := 0; i < queued; i++ {
+		e.BlockCh <- blockAtSlot(uint64(i))
+	}
+
+	if drained := e.drainPendingBlocks(); drained != queued {
+		t.Errorf("drained = %d, want %d", drained, queued)
+	}
+	if remaining := len(e.BlockCh); remaining != 0 {
+		t.Errorf("expected the queued blocks to be consumed, %d left in channel", remaining)
+	}
+}

--- a/internal/node/engine.go
+++ b/internal/node/engine.go
@@ -73,7 +73,8 @@ type Engine struct {
 	// fetchInFlight tracks block roots already queued for by-root fetch so a single
 	// missing parent cannot flood FetchRootCh with duplicate requests. Accessed only
 	// on the dispatch loop (queue on onBlock, clear on receive/exhaustion), so no lock.
-	fetchInFlight map[[32]byte]bool
+	fetchInFlight  map[[32]byte]bool
+	topicMeshSizes atomic.Pointer[map[string]int]
 
 	// aggregatedSlot is the last slot for which an aggregation session was
 	// dispatched, so the early (attestation-arrival) path and the interval-2

--- a/internal/node/range_test.go
+++ b/internal/node/range_test.go
@@ -36,7 +36,7 @@ func makeChainStore(t *testing.T, slots []uint64) (*store.ConsensusStore, map[ui
 func TestGetCanonicalBlocksInRange_FullChain(t *testing.T) {
 	s, roots := makeChainStore(t, []uint64{0, 2, 5, 7})
 
-	got := s.GetCanonicalBlocksInRange(0, 8)
+	got, _ := s.GetCanonicalBlocksInRange(0, 8)
 	if len(got) != 4 {
 		t.Fatalf("expected 4 blocks, got %d", len(got))
 	}
@@ -51,7 +51,7 @@ func TestGetCanonicalBlocksInRange_FullChain(t *testing.T) {
 
 func TestGetCanonicalBlocksInRange_ZeroCount(t *testing.T) {
 	s, _ := makeChainStore(t, []uint64{0, 1, 2})
-	if got := s.GetCanonicalBlocksInRange(0, 0); got != nil {
+	if got, _ := s.GetCanonicalBlocksInRange(0, 0); got != nil {
 		t.Fatalf("expected nil for count=0, got %d blocks", len(got))
 	}
 }
@@ -59,12 +59,12 @@ func TestGetCanonicalBlocksInRange_ZeroCount(t *testing.T) {
 func TestGetCanonicalBlocksInRange_SkipsEmptySlots(t *testing.T) {
 	s, _ := makeChainStore(t, []uint64{0, 2, 5, 7})
 
-	got := s.GetCanonicalBlocksInRange(3, 4)
+	got, _ := s.GetCanonicalBlocksInRange(3, 4)
 	if len(got) != 1 || got[0].Block.Slot != 5 {
 		t.Fatalf("expected single block at slot 5, got %d blocks", len(got))
 	}
 
-	got = s.GetCanonicalBlocksInRange(2, 4)
+	got, _ = s.GetCanonicalBlocksInRange(2, 4)
 	if len(got) != 2 || got[0].Block.Slot != 2 || got[1].Block.Slot != 5 {
 		t.Fatalf("expected blocks at [2, 5], got %d blocks", len(got))
 	}
@@ -73,7 +73,7 @@ func TestGetCanonicalBlocksInRange_SkipsEmptySlots(t *testing.T) {
 func TestGetCanonicalBlocksInRange_AboveHead(t *testing.T) {
 	s, _ := makeChainStore(t, []uint64{0, 2, 5, 7})
 
-	got := s.GetCanonicalBlocksInRange(10, 5)
+	got, _ := s.GetCanonicalBlocksInRange(10, 5)
 	if got != nil {
 		t.Fatalf("expected nil for range above head, got %d blocks", len(got))
 	}
@@ -82,7 +82,7 @@ func TestGetCanonicalBlocksInRange_AboveHead(t *testing.T) {
 func TestGetCanonicalBlocksInRange_AscendingOrder(t *testing.T) {
 	s, _ := makeChainStore(t, []uint64{0, 1, 2, 3, 4, 5})
 
-	got := s.GetCanonicalBlocksInRange(1, 4)
+	got, _ := s.GetCanonicalBlocksInRange(1, 4)
 	if len(got) != 4 {
 		t.Fatalf("expected 4 blocks, got %d", len(got))
 	}
@@ -97,7 +97,7 @@ func TestGetCanonicalBlocksInRange_AscendingOrder(t *testing.T) {
 func TestGetCanonicalBlocksInRange_PartialFromGenesis(t *testing.T) {
 	s, _ := makeChainStore(t, []uint64{0, 1, 2, 3, 4, 5, 6, 7})
 
-	got := s.GetCanonicalBlocksInRange(0, 3)
+	got, _ := s.GetCanonicalBlocksInRange(0, 3)
 	if len(got) != 3 {
 		t.Fatalf("expected 3 blocks, got %d", len(got))
 	}
@@ -105,5 +105,39 @@ func TestGetCanonicalBlocksInRange_PartialFromGenesis(t *testing.T) {
 		if b.Block.Slot != uint64(i) {
 			t.Errorf("blocks[%d].Slot = %d, want %d", i, b.Block.Slot, i)
 		}
+	}
+}
+
+// A chain that does not reach back to startSlot is not an empty range: the walk
+// runs out of ancestors (a checkpoint-synced node below its anchor), and the
+// caller must be able to tell the two apart.
+func TestGetCanonicalBlocksInRange_ReportsIncompleteChain(t *testing.T) {
+	tests := []struct {
+		name         string
+		chain        []uint64
+		startSlot    uint64
+		count        uint64
+		wantBlocks   int
+		wantComplete bool
+	}{
+		{"reaches genesis", []uint64{0, 1, 2, 3}, 0, 4, 4, true},
+		{"walk stops below startSlot", []uint64{0, 1, 2, 3, 4, 5}, 3, 3, 3, true},
+		{"ancestors end above startSlot", []uint64{5, 6, 7}, 0, 8, 3, false},
+		{"anchor above requested range", []uint64{5, 6, 7}, 1, 2, 0, false},
+		{"zero count", []uint64{0, 1, 2}, 0, 0, 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _ := makeChainStore(t, tt.chain)
+
+			got, complete := s.GetCanonicalBlocksInRange(tt.startSlot, tt.count)
+			if len(got) != tt.wantBlocks {
+				t.Errorf("blocks = %d, want %d", len(got), tt.wantBlocks)
+			}
+			if complete != tt.wantComplete {
+				t.Errorf("complete = %v, want %v", complete, tt.wantComplete)
+			}
+		})
 	}
 }

--- a/internal/node/status.go
+++ b/internal/node/status.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -11,6 +12,10 @@ import (
 )
 
 const SyncLagSlots = 2
+
+// gossipMeshSampleInterval paces the mesh-peer gauge. It is an observability
+// sample, not a control input, so it runs well below the slot cadence.
+const gossipMeshSampleInterval = 10 * time.Second
 
 func (e *Engine) updateSyncStatus(currentSlot uint64) {
 	status := e.computeSyncStatus(currentSlot)
@@ -66,10 +71,11 @@ func (e *Engine) logChainStatus(currentSlot uint64) {
 		fcNodesCount = e.FC.Len()
 	}
 
+	// Read the sample runGossipMeshGauge cached rather than querying pubsub here:
+	// the query blocks on the pubsub event loop, and this runs on the tick loop.
 	meshInfo := ""
-	if e.P2P != nil {
-		meshSizes := e.P2P.TopicMeshSizes()
-		for topic, size := range meshSizes {
+	if sizes := e.topicMeshSizes.Load(); sizes != nil {
+		for topic, size := range *sizes {
 			meshInfo += fmt.Sprintf("\n  %-60s mesh_peers=%d", topic, size)
 		}
 	}
@@ -84,9 +90,30 @@ func (e *Engine) logChainStatus(currentSlot uint64) {
 		meshInfo)
 }
 
-func (e *Engine) refreshGossipMeshPeers() {
+// runGossipMeshGauge samples the mesh-peer gauge on its own goroutine. The
+// underlying ListPeers is a synchronous round-trip through the libp2p pubsub
+// event loop, so on a node busy serving req/resp it can block for seconds. Off
+// the tick loop that is a slow gauge; on it, it delayed store.OnTick and stalled
+// the store clock. Sampling is coarse by nature — a slow cadence loses nothing.
+func (e *Engine) runGossipMeshGauge(ctx context.Context) {
 	if e.P2P == nil {
 		return
 	}
+	ticker := time.NewTicker(gossipMeshSampleInterval)
+	defer ticker.Stop()
+	e.sampleGossipMesh()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			e.sampleGossipMesh()
+		}
+	}
+}
+
+func (e *Engine) sampleGossipMesh() {
 	metrics.SetGossipMeshPeers(e.P2P.MeshPeerCount())
+	sizes := e.P2P.TopicMeshSizes()
+	e.topicMeshSizes.Store(&sizes)
 }

--- a/internal/node/tick.go
+++ b/internal/node/tick.go
@@ -23,7 +23,6 @@ func (e *Engine) onTick() {
 
 	metrics.SetCurrentSlot(currentSlot)
 	e.updateSyncStatus(currentSlot)
-	e.refreshGossipMeshPeers()
 
 	isAgg := e.AggCtl != nil && e.AggCtl.Get()
 

--- a/internal/node/workers.go
+++ b/internal/node/workers.go
@@ -12,6 +12,8 @@ func (e *Engine) startWorkers(ctx context.Context) {
 	go e.runProposalWorker(ctx)
 	go e.runRecoveryWorker(ctx)
 	go e.runAttestationWorker(ctx)
+	go e.runAggregationWorker(ctx)
+	go e.runGossipMeshGauge(ctx)
 }
 
 func (e *Engine) runAttestationWorker(ctx context.Context) {
@@ -21,6 +23,23 @@ func (e *Engine) runAttestationWorker(ctx context.Context) {
 			return
 		case att := <-e.AttestationCh:
 			go e.onGossipAttestation(att)
+		}
+	}
+}
+
+// runAggregationWorker verifies gossiped aggregates off the dispatch loop.
+// Verification is a recursive XMSS proof check — the most expensive verify gean
+// does — and on the loop it delayed store.OnTick, stalling the store clock.
+// Unlike single attestations these are not fanned out per message: the check is
+// CPU-bound, so serialising it here bounds the cost instead of thrashing. The
+// buffers it writes are mutex-protected, so a worker goroutine is safe.
+func (e *Engine) runAggregationWorker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case agg := <-e.AggregationCh:
+			e.onGossipAggregatedAttestation(agg)
 		}
 	}
 }

--- a/internal/p2p/handlers.go
+++ b/internal/p2p/handlers.go
@@ -11,7 +11,7 @@ func (h *Host) RegisterReqRespHandlers(
 	statusFn func() *StatusMessage,
 	blockByRootFn func(root [32]byte) *types.SignedBlock,
 	currentSlotFn func() uint64,
-	blocksInRangeFn func(startSlot, count uint64) []*types.SignedBlock,
+	blocksInRangeFn func(startSlot, count uint64) ([]*types.SignedBlock, bool),
 ) {
 	h.host.SetStreamHandler(protocol.ID(StatusProtocol), func(s network.Stream) {
 		defer s.Close()

--- a/internal/p2p/range.go
+++ b/internal/p2p/range.go
@@ -19,7 +19,7 @@ import (
 func handleBlocksByRangeRequest(
 	stream network.Stream,
 	currentSlotFn func() uint64,
-	blocksInRangeFn func(startSlot, count uint64) []*types.SignedBlock,
+	blocksInRangeFn func(startSlot, count uint64) ([]*types.SignedBlock, bool),
 ) {
 	armReadDeadline(stream)
 	reqBuf, err := io.ReadAll(io.LimitReader(stream, int64(MaxCompressedPayloadSize)))
@@ -59,7 +59,16 @@ func handleBlocksByRangeRequest(
 	logger.Info(logger.Network, "blocks_by_range: peer requested start_slot=%d count=%d current_slot=%d",
 		req.StartSlot, req.Count, currentSlot)
 
-	for _, block := range blocksInRangeFn(req.StartSlot, req.Count) {
+	blocks, complete := blocksInRangeFn(req.StartSlot, req.Count)
+	// An incomplete ancestor chain is not an empty range. Serving it as a clean
+	// empty stream tells the requester this range does not exist, so it stops
+	// instead of asking a peer that can answer.
+	if !complete {
+		writeResponse(stream, "blocks_by_range", RespResourceUnavailable, []byte("history below stored chain"))
+		return
+	}
+
+	for _, block := range blocks {
 		if block == nil || block.Block == nil {
 			continue
 		}

--- a/internal/store/backend_test.go
+++ b/internal/store/backend_test.go
@@ -49,7 +49,7 @@ func TestReadMethodsHandleNilBackend(t *testing.T) {
 	if got := s.HeadSlot(); got != 0 {
 		t.Fatalf("head slot=%d, want 0", got)
 	}
-	if got := s.GetCanonicalBlocksInRange(0, 1); got != nil {
+	if got, _ := s.GetCanonicalBlocksInRange(0, 1); got != nil {
 		t.Fatalf("canonical blocks=%v, want nil", got)
 	}
 	if roots, err := s.BlockRoots(); err == nil || roots != nil {

--- a/internal/store/blocks.go
+++ b/internal/store/blocks.go
@@ -210,17 +210,27 @@ func (s *ConsensusStore) PutLiveChainEntry(slot uint64, root, parentRoot [32]byt
 	return s.putOne(storage.TableLiveChain, key, parentRoot[:], "insert live chain entry")
 }
 
-func (s *ConsensusStore) GetCanonicalBlocksInRange(startSlot, count uint64) []*types.SignedBlock {
+// GetCanonicalBlocksInRange returns the canonical blocks in [startSlot, startSlot+count),
+// walking back from head along the ancestor chain. The second return reports whether the
+// walk actually reached startSlot: a false means the ancestor chain ran out first (a
+// checkpoint-synced or restarted node has no blocks below its anchor), which is not the
+// same answer as "this range is empty" and must not be served as one.
+func (s *ConsensusStore) GetCanonicalBlocksInRange(startSlot, count uint64) ([]*types.SignedBlock, bool) {
 	if count == 0 || startSlot > ^uint64(0)-count {
-		return nil
+		return nil, false
 	}
 
 	endSlot := startSlot + count
 	var blocks []*types.SignedBlock
+	complete := false
 	root := s.Head()
 	for {
 		header := s.GetBlockHeader(root)
-		if header == nil || header.Slot < startSlot {
+		if header == nil {
+			break
+		}
+		if header.Slot < startSlot {
+			complete = true
 			break
 		}
 		if header.Slot < endSlot {
@@ -229,6 +239,7 @@ func (s *ConsensusStore) GetCanonicalBlocksInRange(startSlot, count uint64) []*t
 			}
 		}
 		if header.Slot == 0 {
+			complete = true
 			break
 		}
 		root = header.ParentRoot
@@ -237,5 +248,5 @@ func (s *ConsensusStore) GetCanonicalBlocksInRange(startSlot, count uint64) []*t
 	for i, j := 0, len(blocks)-1; i < j; i, j = i+1, j-1 {
 		blocks[i], blocks[j] = blocks[j], blocks[i]
 	}
-	return blocks
+	return blocks, complete
 }

--- a/internal/syncer/backfill.go
+++ b/internal/syncer/backfill.go
@@ -20,6 +20,11 @@ func (sd *SyncDriver) checkAndBackfill(ctx context.Context, peerID libp2ppeer.ID
 	if !sd.shouldBackfill(peerStatus) {
 		return
 	}
+	if sd.beyondHistoryHorizon(peerStatus) {
+		sd.reportBeyondHistoryHorizon(peerID, peerStatus)
+		return
+	}
+	sd.clearBeyondHistoryHorizon()
 	if !sd.tryReserve(peerID) {
 		return
 	}
@@ -57,6 +62,48 @@ func (sd *SyncDriver) checkAndBackfill(ctx context.Context, peerID libp2ppeer.ID
 		}
 		startSlot = lastSlot + 1
 	}
+}
+
+// beyondHistoryHorizon reports whether our head has fallen so far behind the peer
+// that every request we could make starts below the peer's serving window. The
+// spec pins that window to the responder's current slot
+// (MIN_SLOTS_FOR_BLOCK_REQUESTS), and a start slot below it is answered with
+// RESOURCE_UNAVAILABLE, so no range request from our head can ever be served.
+// Falling forward to a servable start slot would not help either: the blocks
+// returned would have no parent state here and could only churn the pending
+// buffer. Closing a gap this wide requires checkpoint sync.
+func (sd *SyncDriver) beyondHistoryHorizon(peerStatus *p2p.StatusMessage) bool {
+	if sd == nil || sd.store == nil || peerStatus == nil {
+		return false
+	}
+	ourHead := sd.store.HeadSlot()
+	return peerStatus.HeadSlot > ourHead &&
+		peerStatus.HeadSlot-ourHead > types.MinSlotsForBlockRequests
+}
+
+// reportBeyondHistoryHorizon states the condition once per episode. Without the
+// latch this fires for every peer on every poll, burying the one line an operator
+// needs under a repeating log; without the report at all the node just retries an
+// unanswerable request forever and looks merely slow.
+func (sd *SyncDriver) reportBeyondHistoryHorizon(peerID libp2ppeer.ID, peerStatus *p2p.StatusMessage) {
+	sd.mu.Lock()
+	alreadyReported := sd.horizonReported
+	sd.horizonReported = true
+	sd.mu.Unlock()
+	if alreadyReported {
+		return
+	}
+	logger.Error(logger.Sync,
+		"sync: head %d is %d slots behind peer %s (head %d), past the %d-slot block-request window; "+
+			"range backfill cannot recover this gap — restart with --checkpoint-sync-url to re-anchor",
+		sd.store.HeadSlot(), peerStatus.HeadSlot-sd.store.HeadSlot(), peerID,
+		peerStatus.HeadSlot, types.MinSlotsForBlockRequests)
+}
+
+func (sd *SyncDriver) clearBeyondHistoryHorizon() {
+	sd.mu.Lock()
+	sd.horizonReported = false
+	sd.mu.Unlock()
 }
 
 func (sd *SyncDriver) shouldBackfill(peerStatus *p2p.StatusMessage) bool {

--- a/internal/syncer/driver.go
+++ b/internal/syncer/driver.go
@@ -19,6 +19,9 @@ type SyncDriver struct {
 
 	mu       sync.Mutex
 	inFlight map[libp2ppeer.ID]bool
+	// horizonReported latches the beyond-window report so it is stated once per
+	// episode rather than once per peer per poll.
+	horizonReported bool
 }
 
 func NewSyncDriver(ctx context.Context, node LocalNode, store *store.ConsensusStore, p2pHost SyncDriverP2P) *SyncDriver {

--- a/internal/syncer/horizon_test.go
+++ b/internal/syncer/horizon_test.go
@@ -1,0 +1,110 @@
+package syncer
+
+import (
+	"context"
+	"testing"
+
+	libp2ppeer "github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/geanlabs/gean/internal/p2p"
+	"github.com/geanlabs/gean/internal/types"
+)
+
+// setHeadAtSlot anchors the store's head at slot so HeadSlot() reflects it.
+func setHeadAtSlot(t *testing.T, sd *SyncDriver, slot uint64) {
+	t.Helper()
+	head := &types.BlockHeader{Slot: slot}
+	root := mustHeaderRoot(head)
+	sd.store.SetHead(root)
+	sd.store.InsertBlockHeader(root, head)
+}
+
+func TestSyncDriver_BeyondHistoryHorizon(t *testing.T) {
+	tests := []struct {
+		name     string
+		ourHead  uint64
+		peerHead uint64
+		want     bool
+	}{
+		{"peer behind us", 5000, 100, false},
+		{"peer level", 5000, 5000, false},
+		{"gap inside window", 5000, 5000 + types.MinSlotsForBlockRequests, false},
+		{"gap exactly at window edge", 100, 100 + types.MinSlotsForBlockRequests, false},
+		{"gap one past the window", 100, 101 + types.MinSlotsForBlockRequests, true},
+		{"devnet-5 observed gap", 97861, 103265, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n, st := makeTestSyncHarness()
+			sd := NewSyncDriver(context.Background(), n, st, &mockSyncP2P{})
+			setHeadAtSlot(t, sd, tt.ourHead)
+
+			got := sd.beyondHistoryHorizon(&p2p.StatusMessage{HeadSlot: tt.peerHead})
+			if got != tt.want {
+				t.Errorf("beyondHistoryHorizon(our=%d peer=%d) = %v, want %v",
+					tt.ourHead, tt.peerHead, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSyncDriver_BeyondHistoryHorizon_NilInputs(t *testing.T) {
+	n, st := makeTestSyncHarness()
+	sd := NewSyncDriver(context.Background(), n, st, &mockSyncP2P{})
+
+	if sd.beyondHistoryHorizon(nil) {
+		t.Error("nil peer status must not report beyond-horizon")
+	}
+	var nilDriver *SyncDriver
+	if nilDriver.beyondHistoryHorizon(&p2p.StatusMessage{HeadSlot: 1 << 20}) {
+		t.Error("nil driver must not report beyond-horizon")
+	}
+}
+
+// A gap past the window can only be answered with RESOURCE_UNAVAILABLE, so the
+// driver must stop asking rather than reissue an unanswerable request every poll.
+func TestSyncDriver_CheckAndBackfill_SkipsRequestBeyondHorizon(t *testing.T) {
+	n, st := makeTestSyncHarness()
+	mock := &mockSyncP2P{}
+	sd := NewSyncDriver(context.Background(), n, st, mock)
+	setHeadAtSlot(t, sd, 97861)
+
+	peerStatus := &p2p.StatusMessage{HeadSlot: 103265, FinalizedSlot: 92908}
+	for i := 0; i < 3; i++ {
+		sd.checkAndBackfill(context.Background(), libp2ppeer.ID("p1"), peerStatus)
+	}
+
+	if got := mock.rangeCalls.Load(); got != 0 {
+		t.Errorf("expected no range requests beyond the block-request window, got %d", got)
+	}
+	if got := mock.rootCalls.Load(); got != 0 {
+		t.Errorf("expected no by-root fallback beyond the window, got %d", got)
+	}
+}
+
+// The report latches so it states the condition once, and unlatches once the node
+// is back inside the window so a later episode is reported again.
+func TestSyncDriver_BeyondHorizonReportLatch(t *testing.T) {
+	n, st := makeTestSyncHarness()
+	sd := NewSyncDriver(context.Background(), n, st, &mockSyncP2P{})
+	setHeadAtSlot(t, sd, 100)
+
+	far := &p2p.StatusMessage{HeadSlot: 100 + types.MinSlotsForBlockRequests + 1}
+	sd.checkAndBackfill(context.Background(), libp2ppeer.ID("p1"), far)
+	if !sd.horizonReported {
+		t.Fatal("expected beyond-horizon condition to latch")
+	}
+
+	sd.checkAndBackfill(context.Background(), libp2ppeer.ID("p2"), far)
+	if !sd.horizonReported {
+		t.Fatal("latch must stay set while the condition holds")
+	}
+
+	// Back inside the window: the gap is servable again, so the latch clears.
+	near := &p2p.StatusMessage{HeadSlot: 100 + blocksByRangeSyncThreshold + 1}
+	sd.checkAndBackfill(context.Background(), libp2ppeer.ID("p3"), near)
+	if sd.horizonReported {
+		t.Fatal("expected latch to clear once the gap is inside the window")
+	}
+}


### PR DESCRIPTION
Three defects found by auditing the devnet-5 interop logs of 2026-08-26, where all eight gean nodes ran a slot clock 2–4 slots behind wall clock, rejected live blocks as "beyond future horizon", and produced 0–4 blocks/h. One commit per issue.

Closes #412
Closes #413
Closes #414

## What the logs showed

Genesis was recovered from gossip arrival times (arrival offset 0–1655 ms into slot, median 174 ms), so every figure below is checkable against wall clock.

- **The dispatch loop was the delay, not the network.** Time from `[gossip] received block` to `[chain] processing block` for the same root — both timestamps from the same process: p50 5.5 s / 28.9 s, p90 61 s / 85 s, max 130 s.
- **Import itself was fast.** `proc_time` p50 83–94 ms over 378 imports; 98% of the second window sat in gaps *between* imports at 0.15 blocks/s. The loop was blocked on in-loop work that logs nothing.
- **The tick ran at ~1/60th of its rate.** `CHAIN STATUS` (interval 1, so once per slot) appeared 24 times in 35 minutes instead of ~525. Wall clock at emit vs. the `Current Slot` computed at the top of the same `onTick`: 19–51 slots, i.e. **76–204 s elapsed inside a single invocation**.
- **1,464 identical range requests**, 100% empty (632/632 and 912/912), every one with a peer gap of 5403–5599 slots against `MIN_SLOTS_FOR_BLOCK_REQUESTS = 3600`.
- The cohort was frozen together: peer status showed `head_slot=97861` ×2828 and `head_slot=94649` ×183 while the network ran at 103265+.

## The changes

**`fix(node)` — #412.** `store.time` only advances inside `store.OnTick`, which runs on the dispatch loop, so a long `onTick` leaves the clock stale and `on_block` rejects correctly-timed blocks. Three sources removed:
- `drainPendingBlocks` now imports only what was queued on entry. Sync delivery blocks on `BlockCh`, so a producer refilled every slot the drain freed — draining until the channel read empty handed the loop unbounded work, *after* `OnTick` had already run for that tick.
- The mesh-peer gauge moved to its own goroutine at 10 s, with the chain-status log reading its cached sample. `ListPeers` is a synchronous round-trip through the libp2p pubsub event loop, and it ran *before* `OnTick`.
- Gossiped aggregates verify on a dedicated worker. Serialised rather than fanned out per message, since the recursive XMSS check is CPU-bound.

`OnTick` keeps its interval side effects and its ordering against `updateHead`, both still on the dispatch loop — moving promotion off would split an operation the spec orders.

**`fix(syncer)` — #413.** Backfill starts at `HeadSlot()+1`; past the window that start slot is below every peer's floor, which the spec answers with `RESOURCE_UNAVAILABLE` (`networking/config.py`). Detect it before requesting and state it once per episode with the action that recovers it. Falling forward to a servable start slot is deliberately **not** attempted: those blocks have no parent state locally and could only churn the pending buffer. A gap this wide needs checkpoint sync.

**`fix(p2p)` — #414.** The window slides with the responder's *current slot*, but gean fed the handler its *head slot* — a lagging head advertised a lower floor and offered history the spec permits pruning, and let the canonical walk run past the bound the window implies. `GetCanonicalBlocksInRange` now also reports whether the walk reached the requested start slot; an ancestor chain that runs out first is not an empty range, and serving it as one tells the requester this history does not exist. That case returns `RESOURCE_UNAVAILABLE`.

## Spec

Verified against pin `eca701e`. The future-horizon check in `blockprocessor` already mirrors `lstar/fork_choice.py` exactly (`store.time // INTERVALS_PER_SLOT`, `block.slot > current_slot + 1`) and is unchanged — the check was right, the clock feeding it was not. The `RESOURCE_UNAVAILABLE` floor is spec-mandated and is likewise unchanged; only its input was wrong.

## Testing

- `make build`, `make lint`, `go vet ./...` clean.
- `make test` — all 25 packages green.
- `go test -race ./internal/node ./internal/syncer ./internal/store ./internal/p2p` clean.
- New coverage: table-driven `beyondHistoryHorizon` incl. the window edge and the observed devnet gap; the report latch set/clear; the bounded drain (verified to **fail** against the old unbounded drain, so it actually discriminates); `GetCanonicalBlocksInRange` completeness across five chain shapes.
- No stream-level test for the new `RESOURCE_UNAVAILABLE` branch — it is a boolean branch on a value the store-level tests cover, and a libp2p stream mock is more scaffolding than the branch warrants.

## Live devnet run

3 gean nodes in Docker on the image built from these commits, 5 minutes / ~75 slots, config from `bin/keygen` (the local quickstart tooling emits 48-byte genesis pubkeys and this branch requires 32).

| | devnet-5 incident | this run |
|---|---|---|
| gossip → import delay | p50 5.5–29 s, p90 61–85 s, max 130 s | **p50 0 ms, p90 1 ms, max 31 ms** |
| tick lag vs wall clock | 19–51 slots (76–204 s) | **`Behind: 0`** |
| `CHAIN STATUS` cadence | 24 lines / 35 min | **74 lines / 74 slots** |
| future-horizon rejections | 36 | **0** |
| `block channel full` drops | 19 in 5 min | **0** |
| `pending block cache full` | 173 in 5 min | **0** |

All three nodes ended on identical head/justified/finalized roots (head 83, justified 79, finalized 75) with zero ERROR lines. Containers removed after the run.

The beyond-window path (#413) is not exercised by a healthy 3-node net; it is covered by unit tests instead, including the exact gap observed on devnet-5.
