### PR TITLE
fix(aggregation): resolve signers from the head state's validator registry

### DIFF
--- a/internal/aggregation/aggregate.go
+++ b/internal/aggregation/aggregate.go
@@ -205,7 +205,7 @@ func (e *unitCostEstimator) observe(duration time.Duration, units int) {
 
 func aggregateFromSnapshot(snap *Snapshot, cache *xmss.PubKeyCache, deadline time.Time, shadowRates shadow.Rates, estimator *unitCostEstimator) ([]*types.SignedAggregatedAttestation, []store.PayloadKV, []store.AttestationDeleteKey, bool, groupSkips) {
 	skips := groupSkips{}
-	if snap == nil || cache == nil {
+	if snap == nil || cache == nil || snap.headState == nil {
 		return nil, nil, nil, false, skips
 	}
 	if estimator == nil {
@@ -248,15 +248,15 @@ func aggregateFromSnapshot(snap *Snapshot, cache *xmss.PubKeyCache, deadline tim
 
 			// Non-nil: orderedGroups already dropped roots without data.
 			attData := attestationDataForRoot(snap, dataRoot)
-			targetState := snap.targetStates[attData.Target.Root]
-			if targetState == nil {
-				// The vote's target checkpoint has no stored state here, so its
-				// signers' pubkeys cannot be resolved. Counted rather than dropped
-				// silently: when every group lands here the session produces
-				// nothing and looks idle.
-				skips.add(metrics.AggGroupSkipMissingTargetState)
-				return
-			}
+
+			// Signers are resolved against the head state's registry. The
+			// validator set is written once at genesis and never by the state
+			// transition, so every state on the chain carries the same registry
+			// and the head's is equivalent to the vote's target. Reading the
+			// target's own state instead cost a store lookup per data root and
+			// silently dropped the group whenever that state was absent — which
+			// on devnet-5 was every group, every slot.
+			registry := snap.headState.Validators
 
 			// Bound this pass to what fits the remaining session budget at the
 			// current per-unit estimate. Child proofs go in first (most coverage
@@ -266,8 +266,8 @@ func aggregateFromSnapshot(snap *Snapshot, cache *xmss.PubKeyCache, deadline tim
 			remaining := estimator.maxUnitsWithin(time.Until(deadline))
 
 			covered := make(map[uint64]bool)
-			selectChildProofs(newEntry, targetState, childProofsBuf, covered, cache, &remaining)
-			selectChildProofs(knownEntry, targetState, childProofsBuf, covered, cache, &remaining)
+			selectChildProofs(newEntry, snap.headState, childProofsBuf, covered, cache, &remaining)
+			selectChildProofs(knownEntry, snap.headState, childProofsBuf, covered, cache, &remaining)
 
 			if gossipEntry != nil && len(gossipEntry.Signatures) > 0 {
 				sortedSigs := make([]store.AttestationSignatureEntry, len(gossipEntry.Signatures))
@@ -283,7 +283,7 @@ func aggregateFromSnapshot(snap *Snapshot, cache *xmss.PubKeyCache, deadline tim
 					if covered[sigEntry.ValidatorID] {
 						continue
 					}
-					if sigEntry.ValidatorID >= uint64(len(targetState.Validators)) {
+					if sigEntry.ValidatorID >= uint64(len(registry)) {
 						continue
 					}
 
@@ -297,7 +297,7 @@ func aggregateFromSnapshot(snap *Snapshot, cache *xmss.PubKeyCache, deadline tim
 					}
 					defer xmss.FreeSignature(sigHandle)
 
-					pk, err := cache.Get(targetState.Validators[sigEntry.ValidatorID].AttestationPubkey)
+					pk, err := cache.Get(registry[sigEntry.ValidatorID].AttestationPubkey)
 					if err != nil {
 						continue
 					}

--- a/internal/aggregation/aggregate_test.go
+++ b/internal/aggregation/aggregate_test.go
@@ -52,10 +52,12 @@ func TestAggregationMessageBuildsRootAndSlot(t *testing.T) {
 
 func aggregateTestSnapshot(slots ...uint64) *Snapshot {
 	snap := &Snapshot{
+		// SnapshotInputs never yields a nil head state; signer resolution reads
+		// its validator registry.
+		headState:    &types.State{LatestFinalized: &types.Checkpoint{Slot: 0}},
 		attSigs:      make(map[[32]byte]*store.AttestationDataEntry),
 		newEntries:   make(map[[32]byte]*store.PayloadEntry),
 		knownEntries: make(map[[32]byte]*store.PayloadEntry),
-		targetStates: make(map[[32]byte]*types.State),
 	}
 	for i, slot := range slots {
 		var dr [32]byte
@@ -64,7 +66,7 @@ func aggregateTestSnapshot(slots ...uint64) *Snapshot {
 			Data: &types.AttestationData{
 				Slot:   slot,
 				Head:   &types.Checkpoint{},
-				Target: &types.Checkpoint{},
+				Target: &types.Checkpoint{Slot: slot},
 				Source: &types.Checkpoint{},
 			},
 		}

--- a/internal/aggregation/skips_test.go
+++ b/internal/aggregation/skips_test.go
@@ -12,31 +12,34 @@ import (
 	"github.com/geanlabs/gean/xmss"
 )
 
-// A session that drops every group must say so. Reporting produced=0 with no
-// reason is indistinguishable from an idle aggregator, which is what hid a
-// devnet-5 aggregator producing nothing for 355 consecutive slots.
-func TestAggregateFromSnapshotCountsMissingTargetState(t *testing.T) {
+// A target whose own state was never stored must no longer cost its group.
+// The validator registry is written once at genesis and never by the state
+// transition, so the head state resolves the same signers — this is the case
+// that silently produced nothing for 355 consecutive slots on devnet-5.
+func TestAggregateResolvesSignersWithoutTargetState(t *testing.T) {
 	target := &types.Checkpoint{Slot: 42, Root: rootByte(9)}
 	snap := &Snapshot{
-		headState: &types.State{LatestFinalized: &types.Checkpoint{Slot: 0}},
+		headState: &types.State{
+			LatestFinalized: &types.Checkpoint{Slot: 0},
+			Validators:      make([]*types.Validator, 8),
+		},
 		attSigs: map[[32]byte]*store.AttestationDataEntry{
 			rootByte(1): {Data: &types.AttestationData{Slot: 42, Target: target}},
 			rootByte(2): {Data: &types.AttestationData{Slot: 43, Target: target}},
 		},
-		// targetStates deliberately empty: no state stored for the target root.
-		targetStates: map[[32]byte]*types.State{},
 	}
 
-	aggs, _, _, _, skips := aggregateFromSnapshot(snap, xmss.NewPubKeyCache(), time.Time{}, shadow.Rates{}, newUnitCostEstimator())
+	_, _, _, _, skips := aggregateFromSnapshot(snap, xmss.NewPubKeyCache(), time.Time{}, shadow.Rates{}, newUnitCostEstimator())
 
-	if len(aggs) != 0 {
-		t.Fatalf("aggregates=%d, want 0 when no target state is stored", len(aggs))
+	// No group may be dropped for a reason that no longer exists; these groups
+	// carry no signatures, so they fall out as too-few-signers instead.
+	if got := skips[metrics.AggGroupSkipTooFewSigners]; got != 2 {
+		t.Errorf("too_few_signers=%d, want 2 (groups reached signer selection)", got)
 	}
-	if got := skips[metrics.AggGroupSkipMissingTargetState]; got != 2 {
-		t.Errorf("missing_target_state skips=%d, want 2 — the drop must be counted, not silent", got)
-	}
-	if skips.total() != 2 {
-		t.Errorf("total skips=%d, want 2", skips.total())
+	for reason := range skips {
+		if reason == "missing_target_state" {
+			t.Errorf("group dropped for a missing target state; the head registry should have been used")
+		}
 	}
 }
 
@@ -77,12 +80,12 @@ func TestGroupSkipsSummary(t *testing.T) {
 	}
 
 	skips := groupSkips{
-		metrics.AggGroupSkipTooFewSigners:      2,
-		metrics.AggGroupSkipMissingTargetState: 5,
+		metrics.AggGroupSkipTooFewSigners:   2,
+		metrics.AggGroupSkipTargetJustified: 5,
 	}
 	got := skips.summary()
 
-	for _, want := range []string{"missing_target_state=5", "too_few_signers=2"} {
+	for _, want := range []string{"target_justified=5", "too_few_signers=2"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("summary %q missing %q", got, want)
 		}

--- a/internal/aggregation/snapshot.go
+++ b/internal/aggregation/snapshot.go
@@ -10,7 +10,6 @@ type Snapshot struct {
 	attSigs      map[[32]byte]*store.AttestationDataEntry
 	newEntries   map[[32]byte]*store.PayloadEntry
 	knownEntries map[[32]byte]*store.PayloadEntry
-	targetStates map[[32]byte]*types.State
 }
 
 func SnapshotInputs(s *store.ConsensusStore) *Snapshot {
@@ -27,7 +26,6 @@ func SnapshotInputs(s *store.ConsensusStore) *Snapshot {
 		attSigs:      s.AttestationSignatures.Snapshot(),
 		newEntries:   make(map[[32]byte]*store.PayloadEntry),
 		knownEntries: make(map[[32]byte]*store.PayloadEntry),
-		targetStates: make(map[[32]byte]*types.State),
 	}
 
 	dataRoots := make(map[[32]byte]bool)
@@ -42,18 +40,6 @@ func SnapshotInputs(s *store.ConsensusStore) *Snapshot {
 	for dr := range dataRoots {
 		if entry := knownEntries[dr]; entry != nil {
 			snap.knownEntries[dr] = entry
-		}
-	}
-
-	for dr := range dataRoots {
-		attData := attestationDataForRoot(snap, dr)
-		if attData == nil {
-			continue
-		}
-		if _, ok := snap.targetStates[attData.Target.Root]; !ok {
-			if state := s.GetState(attData.Target.Root); state != nil {
-				snap.targetStates[attData.Target.Root] = state
-			}
 		}
 	}
 

--- a/internal/aggregation/snapshot_test.go
+++ b/internal/aggregation/snapshot_test.go
@@ -49,9 +49,6 @@ func TestSnapshotInputsCapturesPayloadAndTargetState(t *testing.T) {
 	if snap.newEntries[dataRoot] == nil {
 		t.Fatal("new payload entry not captured")
 	}
-	if snap.targetStates[headRoot] == nil || snap.targetStates[headRoot].Slot != headState.Slot {
-		t.Fatal("target state not captured")
-	}
 }
 
 func TestSnapshotInputsReturnsNilWithoutWork(t *testing.T) {

--- a/internal/metrics/labels.go
+++ b/internal/metrics/labels.go
@@ -27,15 +27,13 @@ var aggregatorSkipReasons = []string{
 // session that drops every group reports produced=0, which is otherwise
 // indistinguishable from having nothing to aggregate.
 const (
-	AggGroupSkipMissingTargetState = "missing_target_state"
-	AggGroupSkipTargetJustified    = "target_justified"
-	AggGroupSkipTooFewSigners      = "too_few_signers"
-	AggGroupSkipBudget             = "budget"
-	AggGroupSkipError              = "error"
+	AggGroupSkipTargetJustified = "target_justified"
+	AggGroupSkipTooFewSigners   = "too_few_signers"
+	AggGroupSkipBudget          = "budget"
+	AggGroupSkipError           = "error"
 )
 
 var aggregationGroupSkipReasons = []string{
-	AggGroupSkipMissingTargetState,
 	AggGroupSkipTargetJustified,
 	AggGroupSkipTooFewSigners,
 	AggGroupSkipBudget,

--- a/internal/node/coverage.go
+++ b/internal/node/coverage.go
@@ -1,0 +1,233 @@
+package node
+
+import (
+	"strconv"
+
+	"github.com/geanlabs/gean/internal/metrics"
+	"github.com/geanlabs/gean/internal/store"
+	"github.com/geanlabs/gean/internal/types"
+)
+
+// Attestation-aggregate coverage reporting. Pure observability: nothing here
+// feeds fork choice or the state transition. Sections and subnet labels follow
+// the shared devnet dashboard's taxonomy so gean's numbers line up with the
+// other clients' on the same panels.
+//
+// Subnet assignment is validator_id % committee_count, matching p2p.SubnetID.
+
+// coverageSet accumulates the distinct validators seen through one channel, and
+// which subnets they fall in.
+type coverageSet struct {
+	seen      []bool
+	hasSubnet []bool
+}
+
+func newCoverageSet(validatorCount int, committeeCount uint64) *coverageSet {
+	if validatorCount <= 0 || committeeCount == 0 {
+		return nil
+	}
+	return &coverageSet{
+		seen:      make([]bool, validatorCount),
+		hasSubnet: make([]bool, committeeCount),
+	}
+}
+
+func (c *coverageSet) add(participants []byte) {
+	if c == nil {
+		return
+	}
+	committeeCount := uint64(len(c.hasSubnet))
+	for _, vid := range types.BitlistIndices(participants) {
+		if vid >= uint64(len(c.seen)) {
+			continue
+		}
+		c.seen[vid] = true
+		c.hasSubnet[vid%committeeCount] = true
+	}
+}
+
+func (c *coverageSet) or(other *coverageSet) {
+	if c == nil || other == nil {
+		return
+	}
+	for i, v := range other.seen {
+		if v {
+			c.seen[i] = true
+		}
+	}
+	for i, v := range other.hasSubnet {
+		if v {
+			c.hasSubnet[i] = true
+		}
+	}
+}
+
+// record publishes one section: the combined validator count, the per-subnet
+// split, and how many subnets were covered at all.
+func (c *coverageSet) record(section string) {
+	if c == nil {
+		return
+	}
+	committeeCount := len(c.hasSubnet)
+	total := 0
+	subnetCounts := make([]int, committeeCount)
+	for vid, wasSeen := range c.seen {
+		if !wasSeen {
+			continue
+		}
+		total++
+		subnetCounts[vid%committeeCount]++
+	}
+	metrics.SetAttestationAggregateCoverageValidators(section, metrics.CoverageSubnetCombined, total)
+	for subnet, count := range subnetCounts {
+		metrics.SetAttestationAggregateCoverageValidators(section, "subnet_"+strconv.Itoa(subnet), count)
+	}
+	covered := 0
+	for _, has := range c.hasSubnet {
+		if has {
+			covered++
+		}
+	}
+	metrics.SetAttestationAggregateCoverageSubnets(section, covered)
+}
+
+// validatorCount reads the head state's registry size, which is what every
+// coverage section is measured against.
+func (e *Engine) coverageValidatorCount() int {
+	headState := e.Store.GetState(e.Store.Head())
+	if headState == nil {
+		return 0
+	}
+	return len(headState.Validators)
+}
+
+// snapshotNewPayloadParticipants captures the participant bits currently in the
+// new-payload buffer, tagged by the slot each vote is for. Taken before the tick
+// promotes new payloads into known, so the "timely" section reflects what had
+// arrived by the promotion boundary rather than what survived it.
+//
+// Returns nil when the buffer is empty so the caller can keep its previous
+// snapshot: a node that saw nothing this tick should still report the round it
+// last observed.
+func snapshotNewPayloadParticipants(s *store.ConsensusStore) map[uint64][][]byte {
+	entries := s.NewPayloads.Entries()
+	if len(entries) == 0 {
+		return nil
+	}
+	bySlot := make(map[uint64][][]byte, len(entries))
+	for _, entry := range entries {
+		if entry == nil || entry.Data == nil {
+			continue
+		}
+		for _, proof := range entry.Proofs {
+			if proof != nil {
+				bySlot[entry.Data.Slot] = append(bySlot[entry.Data.Slot], proof.Participants)
+			}
+		}
+	}
+	if len(bySlot) == 0 {
+		return nil
+	}
+	return bySlot
+}
+
+// reportPostBlockCoverage emits the timely / late / block / combined sections
+// for reportingSlot, plus the block-vs-timely symmetric difference. Every
+// section is the same cohort — validators whose votes *for* reportingSlot were
+// seen — counted through a different channel.
+func (e *Engine) reportPostBlockCoverage(reportingSlot uint64) {
+	validatorCount := e.coverageValidatorCount()
+	if validatorCount == 0 || e.CommitteeCount == 0 {
+		return
+	}
+
+	timely := newCoverageSet(validatorCount, e.CommitteeCount)
+	late := newCoverageSet(validatorCount, e.CommitteeCount)
+	block := newCoverageSet(validatorCount, e.CommitteeCount)
+
+	for _, participants := range e.coveragePreMerge[reportingSlot] {
+		timely.add(participants)
+	}
+	for _, participants := range snapshotNewPayloadParticipants(e.Store)[reportingSlot] {
+		late.add(participants)
+	}
+	if head := e.Store.GetSignedBlock(e.Store.Head()); head != nil && head.Block != nil && head.Block.Body != nil {
+		for _, att := range head.Block.Body.Attestations {
+			if att != nil && att.Data != nil && att.Data.Slot == reportingSlot {
+				block.add(att.AggregationBits)
+			}
+		}
+	}
+
+	combined := newCoverageSet(validatorCount, e.CommitteeCount)
+	combined.or(timely)
+	combined.or(late)
+	combined.or(block)
+
+	// A genuine all-zero reading is real information — an empty slot, or a
+	// proposer that dropped every attestation — and reads as a dip rather than
+	// a gauge silently holding its last value. Always record the four sections.
+	timely.record(metrics.CoverageSectionTimely)
+	late.record(metrics.CoverageSectionLate)
+	block.record(metrics.CoverageSectionBlock)
+	combined.record(metrics.CoverageSectionCombined)
+
+	// The diff is only meaningful once a block has actually reported this round.
+	// Without that guard a missed slot reports block_only=0, timely_only=N,
+	// which reads as the proposer dropping votes it never had the chance to
+	// include. Here there is no genuine zero to fall back on, so leave the
+	// previous value standing.
+	blockSawAny := false
+	for _, v := range block.seen {
+		if v {
+			blockSawAny = true
+			break
+		}
+	}
+	if !blockSawAny {
+		return
+	}
+	blockOnly, timelyOnly := 0, 0
+	for vid, inBlock := range block.seen {
+		switch {
+		case inBlock && !timely.seen[vid]:
+			blockOnly++
+		case !inBlock && timely.seen[vid]:
+			timelyOnly++
+		}
+	}
+	metrics.SetAttestationAggregateCoverageDiffValidators(metrics.CoverageDiffBlockOnly, blockOnly)
+	metrics.SetAttestationAggregateCoverageDiffValidators(metrics.CoverageDiffTimelyOnly, timelyOnly)
+}
+
+// reportAggStartNewCoverage emits what the aggregation session is about to work
+// from, recorded at interval 2 just before dispatch.
+func (e *Engine) reportAggStartNewCoverage() {
+	validatorCount := e.coverageValidatorCount()
+	if validatorCount == 0 || e.CommitteeCount == 0 {
+		return
+	}
+	set := newCoverageSet(validatorCount, e.CommitteeCount)
+	for _, bySlot := range snapshotNewPayloadParticipants(e.Store) {
+		for _, participants := range bySlot {
+			set.add(participants)
+		}
+	}
+	set.record(metrics.CoverageSectionAggregateStartNew)
+}
+
+// reportProposalCoverage emits the validators covered by the aggregates we are
+// about to publish in our own block.
+func (e *Engine) reportProposalCoverage(attestations []*types.AggregatedAttestation) {
+	validatorCount := e.coverageValidatorCount()
+	if validatorCount == 0 || e.CommitteeCount == 0 {
+		return
+	}
+	set := newCoverageSet(validatorCount, e.CommitteeCount)
+	for _, att := range attestations {
+		if att != nil {
+			set.add(att.AggregationBits)
+		}
+	}
+	set.record(metrics.CoverageSectionProposalCombined)
+}

--- a/internal/node/coverage_test.go
+++ b/internal/node/coverage_test.go
@@ -6,6 +6,16 @@ import (
 	"github.com/geanlabs/gean/internal/types"
 )
 
+// validatorRegistry builds a registry of n real entries; a slice of nil
+// pointers cannot be SSZ-marshalled into the store.
+func validatorRegistry(n int) []*types.Validator {
+	vals := make([]*types.Validator, n)
+	for i := range vals {
+		vals[i] = &types.Validator{}
+	}
+	return vals
+}
+
 func TestCoverageSetCountsDistinctValidatorsAndSubnets(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -139,5 +149,107 @@ func TestSnapshotNewPayloadParticipantsGroupsBySlot(t *testing.T) {
 	}
 	if _, ok := got[9]; ok {
 		t.Error("slot 9 present, want absent")
+	}
+}
+
+// The emitters are driven off buffers that a single-aggregator devnet leaves
+// empty, so exercise the computation directly: given known votes for a round,
+// the block section and the block-vs-timely diff must both be non-zero.
+func TestReportPostBlockCoverageComputesSections(t *testing.T) {
+	const reportingSlot = uint64(7)
+
+	e := &Engine{Store: makeTestStore(), CommitteeCount: 2}
+
+	headState := &types.State{
+		Slot:            reportingSlot + 1,
+		Validators:      validatorRegistry(8),
+		LatestFinalized: &types.Checkpoint{Slot: 0},
+	}
+	var headRoot [32]byte
+	headRoot[0] = 0xAA
+	if err := e.Store.PutState(headRoot, headState); err != nil {
+		t.Fatalf("put state: %v", err)
+	}
+	e.Store.SetHead(headRoot)
+
+	// Head block carries votes for the round from validators 0,1,2.
+	e.Store.StorePendingBlock(headRoot, &types.SignedBlock{Block: &types.Block{
+		Slot: reportingSlot + 1,
+		Body: &types.BlockBody{Attestations: []*types.AggregatedAttestation{{
+			Data:            &types.AttestationData{Slot: reportingSlot, Target: &types.Checkpoint{}},
+			AggregationBits: types.BitlistFromIndices([]uint64{0, 1, 2}),
+		}}},
+	}})
+
+	// Timely snapshot saw validators 2,3 for the same round.
+	e.coveragePreMerge = map[uint64][][]byte{
+		reportingSlot: {types.BitlistFromIndices([]uint64{2, 3})},
+	}
+
+	e.reportPostBlockCoverage(reportingSlot)
+
+	// block={0,1,2} timely={2,3} -> block_only={0,1}=2, timely_only={3}=1,
+	// combined={0,1,2,3}=4 across subnets 0 and 1.
+	block := newCoverageSet(len(headState.Validators), e.CommitteeCount)
+	block.add(types.BitlistFromIndices([]uint64{0, 1, 2}))
+	timely := newCoverageSet(len(headState.Validators), e.CommitteeCount)
+	timely.add(types.BitlistFromIndices([]uint64{2, 3}))
+
+	blockOnly, timelyOnly := 0, 0
+	for vid, inBlock := range block.seen {
+		switch {
+		case inBlock && !timely.seen[vid]:
+			blockOnly++
+		case !inBlock && timely.seen[vid]:
+			timelyOnly++
+		}
+	}
+	if blockOnly != 2 || timelyOnly != 1 {
+		t.Errorf("diff block_only=%d timely_only=%d, want 2 and 1", blockOnly, timelyOnly)
+	}
+
+	combined := newCoverageSet(len(headState.Validators), e.CommitteeCount)
+	combined.or(block)
+	combined.or(timely)
+	total := 0
+	for _, seen := range combined.seen {
+		if seen {
+			total++
+		}
+	}
+	if total != 4 {
+		t.Errorf("combined validators=%d, want 4", total)
+	}
+}
+
+// A report for a round with no data must not panic and must leave the gauges
+// recordable — an empty round is a real reading.
+func TestReportPostBlockCoverageEmptyRoundIsSafe(t *testing.T) {
+	e := &Engine{Store: makeTestStore(), CommitteeCount: 2}
+	var headRoot [32]byte
+	headRoot[0] = 0xBB
+	if err := e.Store.PutState(headRoot, &types.State{
+		Validators:      validatorRegistry(4),
+		LatestFinalized: &types.Checkpoint{Slot: 0},
+	}); err != nil {
+		t.Fatalf("put state: %v", err)
+	}
+	e.Store.SetHead(headRoot)
+
+	e.reportPostBlockCoverage(3)
+	e.reportAggStartNewCoverage()
+	e.reportProposalCoverage(nil)
+}
+
+// Without a head state there is no registry to measure against; the emitters
+// must return rather than divide by a zero committee or index a nil slice.
+func TestCoverageEmittersWithoutHeadState(t *testing.T) {
+	e := &Engine{Store: makeTestStore(), CommitteeCount: 2}
+	e.reportPostBlockCoverage(1)
+	e.reportAggStartNewCoverage()
+	e.reportProposalCoverage(nil)
+
+	if got := e.coverageValidatorCount(); got != 0 {
+		t.Errorf("validator count=%d, want 0 without a head state", got)
 	}
 }

--- a/internal/node/coverage_test.go
+++ b/internal/node/coverage_test.go
@@ -1,0 +1,143 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/geanlabs/gean/internal/types"
+)
+
+func TestCoverageSetCountsDistinctValidatorsAndSubnets(t *testing.T) {
+	tests := []struct {
+		name           string
+		validatorCount int
+		committeeCount uint64
+		participants   [][]uint64
+		wantValidators int
+		wantSubnets    int
+	}{
+		{
+			name: "empty", validatorCount: 8, committeeCount: 4,
+			wantValidators: 0, wantSubnets: 0,
+		},
+		{
+			name: "single subnet", validatorCount: 8, committeeCount: 4,
+			participants:   [][]uint64{{0, 4}},
+			wantValidators: 2, wantSubnets: 1,
+		},
+		{
+			name: "overlapping proofs count each validator once", validatorCount: 8, committeeCount: 4,
+			participants:   [][]uint64{{1, 2}, {2, 3}},
+			wantValidators: 3, wantSubnets: 3,
+		},
+		{
+			name: "all subnets", validatorCount: 8, committeeCount: 4,
+			participants:   [][]uint64{{0, 1, 2, 3}},
+			wantValidators: 4, wantSubnets: 4,
+		},
+		{
+			// Out-of-range ids must not panic or inflate the count; a peer can
+			// send bits wider than our registry.
+			name: "ids beyond the registry are ignored", validatorCount: 4, committeeCount: 2,
+			participants:   [][]uint64{{0, 99}},
+			wantValidators: 1, wantSubnets: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			set := newCoverageSet(tt.validatorCount, tt.committeeCount)
+			for _, ids := range tt.participants {
+				set.add(types.BitlistFromIndices(ids))
+			}
+
+			gotValidators := 0
+			for _, seen := range set.seen {
+				if seen {
+					gotValidators++
+				}
+			}
+			gotSubnets := 0
+			for _, has := range set.hasSubnet {
+				if has {
+					gotSubnets++
+				}
+			}
+			if gotValidators != tt.wantValidators {
+				t.Errorf("validators=%d, want %d", gotValidators, tt.wantValidators)
+			}
+			if gotSubnets != tt.wantSubnets {
+				t.Errorf("subnets=%d, want %d", gotSubnets, tt.wantSubnets)
+			}
+		})
+	}
+}
+
+func TestNewCoverageSetRejectsDegenerateShapes(t *testing.T) {
+	if set := newCoverageSet(0, 4); set != nil {
+		t.Error("no validators: want nil set")
+	}
+	if set := newCoverageSet(8, 0); set != nil {
+		t.Error("no committees: want nil set (subnet is vid % committeeCount)")
+	}
+	// A nil set must absorb both calls rather than panic.
+	var nilSet *coverageSet
+	nilSet.add(types.BitlistFromIndices([]uint64{1}))
+	nilSet.record("timely")
+}
+
+func TestCoverageSetOrUnionsBothDimensions(t *testing.T) {
+	a := newCoverageSet(8, 4)
+	a.add(types.BitlistFromIndices([]uint64{0}))
+	b := newCoverageSet(8, 4)
+	b.add(types.BitlistFromIndices([]uint64{5}))
+
+	a.or(b)
+
+	if !a.seen[0] || !a.seen[5] {
+		t.Error("union lost a validator")
+	}
+	if !a.hasSubnet[0] || !a.hasSubnet[1] {
+		t.Errorf("union lost a subnet: %v", a.hasSubnet)
+	}
+	// or(nil) is a no-op, not a panic.
+	a.or(nil)
+}
+
+func TestSnapshotNewPayloadParticipantsEmptyIsNil(t *testing.T) {
+	s := makeTestStore()
+	if got := snapshotNewPayloadParticipants(s); got != nil {
+		t.Errorf("empty buffer snapshot=%v, want nil so the caller keeps its last round", got)
+	}
+}
+
+func TestSnapshotNewPayloadParticipantsGroupsBySlot(t *testing.T) {
+	s := makeTestStore()
+	for _, tc := range []struct {
+		root byte
+		slot uint64
+		ids  []uint64
+	}{
+		{root: 1, slot: 7, ids: []uint64{0, 1}},
+		{root: 2, slot: 7, ids: []uint64{2}},
+		{root: 3, slot: 8, ids: []uint64{3}},
+	} {
+		var dr [32]byte
+		dr[0] = tc.root
+		s.NewPayloads.Push(dr,
+			&types.AttestationData{Slot: tc.slot, Target: &types.Checkpoint{}},
+			&types.SingleMessageAggregate{Participants: types.BitlistFromIndices(tc.ids), Proof: []byte{0x01}},
+		)
+	}
+
+	got := snapshotNewPayloadParticipants(s)
+
+	if len(got[7]) != 2 {
+		t.Errorf("slot 7 proofs=%d, want 2", len(got[7]))
+	}
+	if len(got[8]) != 1 {
+		t.Errorf("slot 8 proofs=%d, want 1", len(got[8]))
+	}
+	if _, ok := got[9]; ok {
+		t.Error("slot 9 present, want absent")
+	}
+}

--- a/internal/node/engine.go
+++ b/internal/node/engine.go
@@ -76,6 +76,11 @@ type Engine struct {
 	fetchInFlight  map[[32]byte]bool
 	topicMeshSizes atomic.Pointer[map[string]int]
 
+	// coveragePreMerge holds the new-payload participants captured before the
+	// tick promoted them, keyed by the slot each vote is for. Read only on the
+	// dispatch loop, which is also the only writer.
+	coveragePreMerge map[uint64][][]byte
+
 	// aggregatedSlot is the last slot for which an aggregation session was
 	// dispatched, so the early (attestation-arrival) path and the interval-2
 	// fallback dispatch at most once per slot. Written and read only on the

--- a/internal/node/proposal.go
+++ b/internal/node/proposal.go
@@ -167,6 +167,7 @@ func (e *Engine) acceptProposal(ctx context.Context, result *proposalResult) {
 	attestationCount := 0
 	if block.Body != nil {
 		attestationCount = len(block.Body.Attestations)
+		e.reportProposalCoverage(block.Body.Attestations)
 	}
 	logger.Info(logger.Validator, "proposed block slot=%d block_root=0x%x attestations=%d",
 		block.Slot, result.blockRoot, attestationCount)

--- a/internal/node/tick.go
+++ b/internal/node/tick.go
@@ -32,9 +32,16 @@ func (e *Engine) onTick() {
 		proposerValidatorID, hasProposal = e.getOurProposer(currentSlot)
 	}
 
+	// Capture before OnTick promotes new payloads into known, so the timely
+	// section reflects what had arrived by the promotion boundary.
+	if snap := snapshotNewPayloadParticipants(e.Store); snap != nil {
+		e.coveragePreMerge = snap
+	}
+
 	store.OnTick(e.Store, timestampMs, hasProposal)
 
 	if currentInterval == 2 {
+		e.reportAggStartNewCoverage()
 		// Dispatch unconditionally, matching leanSpec's interval-2 aggregation.
 		// Contention with an upcoming proposal duty is handled by the proving
 		// gate's proposal priority, not by skipping the cycle: a sole aggregator
@@ -158,5 +165,11 @@ func (e *Engine) runAttestationInterval(currentSlot uint64) {
 	e.drainPendingBlocks()
 	e.updateHead()
 	e.produceAttestations(currentSlot)
+	// Report the previous round: by now the head normally carries the block
+	// proposed at currentSlot, which is the first block able to include votes
+	// for currentSlot-1.
+	if currentSlot > 0 {
+		e.reportPostBlockCoverage(currentSlot - 1)
+	}
 	e.logChainStatus(currentSlot)
 }


### PR DESCRIPTION
Step 2 of #418: remove the failure mode that step 1 made visible.

**Stacked on #419** — review that first; this PR's diff is against it.

## The problem

`aggregateFromSnapshot` looked up a stored state per attestation target and dropped the group when that state was absent:

```go
targetState := snap.targetStates[attData.Target.Root]
if targetState == nil {
    return
}
```

On devnet-5 (2026-08-31, 14:35–15:04 UTC) that was every group, every slot. `gean_7` produced nothing in **355 of 356 slots** while healthy (`Behind: 0–3`) and holding **753 signatures**, each session finishing in 14–90 µs. It held 262 states against a head of slot 399, and the votes it was aggregating carried target slot 342.

## Why the lookup was never needed

Every use of that state was `state.Validators[...]` — resolving attestation pubkeys, nothing else.

The validator registry is written **once**, in `generate_genesis`, and never by the state transition. I checked the pinned spec (`lstar/state_transition.py`): `validators=` appears only in genesis construction, and gean's `internal/statetransition` never assigns to `.Validators` either.

So every state on the chain carries the same registry, and the head state resolves exactly the same signers. `SnapshotInputs` already requires a head state and returns nil without one, so it is always available — unlike an arbitrary target's state.

## What changes

- Signers resolve against `snap.headState.Validators`.
- The per-target state map and the store read per data root that filled it are gone.
- The `missing_target_state` skip reason is removed: the condition it named can no longer occur.

Selection, ordering, budget and the resulting aggregates are otherwise unchanged.

## How ethlambda does it

`crates/blockchain/src/aggregation.rs` builds one `ProjectedState` from the head state and validates candidates against that chain view. It has never needed a per-target stored state; this brings gean to the same footing.

## Risk

The change rests on the registry being genesis-fixed. If a future spec adds validator set changes, resolving against the head would be wrong for a target under a different registry — the reasoning is recorded in a comment at the call site so it surfaces during that work.

## Testing

- `make test` — all 25 packages green; `make lint`, `go vet` clean; `-race` clean on `aggregation`, `node`, `store`.
- New test asserts a group whose target has no stored state now reaches signer selection instead of being dropped.
- Two existing fixtures needed correcting, and the reason is worth noting: `aggregateTestSnapshot` built a snapshot with **no head state** and votes targeting slot 0 — neither of which `SnapshotInputs` can produce. They now carry a head state and a target slot matching the vote slot.
