### PR TITLE
feat(metrics): report attestation-aggregate coverage

### DIFF
--- a/internal/node/coverage.go
+++ b/internal/node/coverage.go
@@ -1,0 +1,233 @@
+package node
+
+import (
+	"strconv"
+
+	"github.com/geanlabs/gean/internal/metrics"
+	"github.com/geanlabs/gean/internal/store"
+	"github.com/geanlabs/gean/internal/types"
+)
+
+// Attestation-aggregate coverage reporting. Pure observability: nothing here
+// feeds fork choice or the state transition. Sections and subnet labels follow
+// the shared devnet dashboard's taxonomy so gean's numbers line up with the
+// other clients' on the same panels.
+//
+// Subnet assignment is validator_id % committee_count, matching p2p.SubnetID.
+
+// coverageSet accumulates the distinct validators seen through one channel, and
+// which subnets they fall in.
+type coverageSet struct {
+	seen      []bool
+	hasSubnet []bool
+}
+
+func newCoverageSet(validatorCount int, committeeCount uint64) *coverageSet {
+	if validatorCount <= 0 || committeeCount == 0 {
+		return nil
+	}
+	return &coverageSet{
+		seen:      make([]bool, validatorCount),
+		hasSubnet: make([]bool, committeeCount),
+	}
+}
+
+func (c *coverageSet) add(participants []byte) {
+	if c == nil {
+		return
+	}
+	committeeCount := uint64(len(c.hasSubnet))
+	for _, vid := range types.BitlistIndices(participants) {
+		if vid >= uint64(len(c.seen)) {
+			continue
+		}
+		c.seen[vid] = true
+		c.hasSubnet[vid%committeeCount] = true
+	}
+}
+
+func (c *coverageSet) or(other *coverageSet) {
+	if c == nil || other == nil {
+		return
+	}
+	for i, v := range other.seen {
+		if v {
+			c.seen[i] = true
+		}
+	}
+	for i, v := range other.hasSubnet {
+		if v {
+			c.hasSubnet[i] = true
+		}
+	}
+}
+
+// record publishes one section: the combined validator count, the per-subnet
+// split, and how many subnets were covered at all.
+func (c *coverageSet) record(section string) {
+	if c == nil {
+		return
+	}
+	committeeCount := len(c.hasSubnet)
+	total := 0
+	subnetCounts := make([]int, committeeCount)
+	for vid, wasSeen := range c.seen {
+		if !wasSeen {
+			continue
+		}
+		total++
+		subnetCounts[vid%committeeCount]++
+	}
+	metrics.SetAttestationAggregateCoverageValidators(section, metrics.CoverageSubnetCombined, total)
+	for subnet, count := range subnetCounts {
+		metrics.SetAttestationAggregateCoverageValidators(section, "subnet_"+strconv.Itoa(subnet), count)
+	}
+	covered := 0
+	for _, has := range c.hasSubnet {
+		if has {
+			covered++
+		}
+	}
+	metrics.SetAttestationAggregateCoverageSubnets(section, covered)
+}
+
+// validatorCount reads the head state's registry size, which is what every
+// coverage section is measured against.
+func (e *Engine) coverageValidatorCount() int {
+	headState := e.Store.GetState(e.Store.Head())
+	if headState == nil {
+		return 0
+	}
+	return len(headState.Validators)
+}
+
+// snapshotNewPayloadParticipants captures the participant bits currently in the
+// new-payload buffer, tagged by the slot each vote is for. Taken before the tick
+// promotes new payloads into known, so the "timely" section reflects what had
+// arrived by the promotion boundary rather than what survived it.
+//
+// Returns nil when the buffer is empty so the caller can keep its previous
+// snapshot: a node that saw nothing this tick should still report the round it
+// last observed.
+func snapshotNewPayloadParticipants(s *store.ConsensusStore) map[uint64][][]byte {
+	entries := s.NewPayloads.Entries()
+	if len(entries) == 0 {
+		return nil
+	}
+	bySlot := make(map[uint64][][]byte, len(entries))
+	for _, entry := range entries {
+		if entry == nil || entry.Data == nil {
+			continue
+		}
+		for _, proof := range entry.Proofs {
+			if proof != nil {
+				bySlot[entry.Data.Slot] = append(bySlot[entry.Data.Slot], proof.Participants)
+			}
+		}
+	}
+	if len(bySlot) == 0 {
+		return nil
+	}
+	return bySlot
+}
+
+// reportPostBlockCoverage emits the timely / late / block / combined sections
+// for reportingSlot, plus the block-vs-timely symmetric difference. Every
+// section is the same cohort — validators whose votes *for* reportingSlot were
+// seen — counted through a different channel.
+func (e *Engine) reportPostBlockCoverage(reportingSlot uint64) {
+	validatorCount := e.coverageValidatorCount()
+	if validatorCount == 0 || e.CommitteeCount == 0 {
+		return
+	}
+
+	timely := newCoverageSet(validatorCount, e.CommitteeCount)
+	late := newCoverageSet(validatorCount, e.CommitteeCount)
+	block := newCoverageSet(validatorCount, e.CommitteeCount)
+
+	for _, participants := range e.coveragePreMerge[reportingSlot] {
+		timely.add(participants)
+	}
+	for _, participants := range snapshotNewPayloadParticipants(e.Store)[reportingSlot] {
+		late.add(participants)
+	}
+	if head := e.Store.GetSignedBlock(e.Store.Head()); head != nil && head.Block != nil && head.Block.Body != nil {
+		for _, att := range head.Block.Body.Attestations {
+			if att != nil && att.Data != nil && att.Data.Slot == reportingSlot {
+				block.add(att.AggregationBits)
+			}
+		}
+	}
+
+	combined := newCoverageSet(validatorCount, e.CommitteeCount)
+	combined.or(timely)
+	combined.or(late)
+	combined.or(block)
+
+	// A genuine all-zero reading is real information — an empty slot, or a
+	// proposer that dropped every attestation — and reads as a dip rather than
+	// a gauge silently holding its last value. Always record the four sections.
+	timely.record(metrics.CoverageSectionTimely)
+	late.record(metrics.CoverageSectionLate)
+	block.record(metrics.CoverageSectionBlock)
+	combined.record(metrics.CoverageSectionCombined)
+
+	// The diff is only meaningful once a block has actually reported this round.
+	// Without that guard a missed slot reports block_only=0, timely_only=N,
+	// which reads as the proposer dropping votes it never had the chance to
+	// include. Here there is no genuine zero to fall back on, so leave the
+	// previous value standing.
+	blockSawAny := false
+	for _, v := range block.seen {
+		if v {
+			blockSawAny = true
+			break
+		}
+	}
+	if !blockSawAny {
+		return
+	}
+	blockOnly, timelyOnly := 0, 0
+	for vid, inBlock := range block.seen {
+		switch {
+		case inBlock && !timely.seen[vid]:
+			blockOnly++
+		case !inBlock && timely.seen[vid]:
+			timelyOnly++
+		}
+	}
+	metrics.SetAttestationAggregateCoverageDiffValidators(metrics.CoverageDiffBlockOnly, blockOnly)
+	metrics.SetAttestationAggregateCoverageDiffValidators(metrics.CoverageDiffTimelyOnly, timelyOnly)
+}
+
+// reportAggStartNewCoverage emits what the aggregation session is about to work
+// from, recorded at interval 2 just before dispatch.
+func (e *Engine) reportAggStartNewCoverage() {
+	validatorCount := e.coverageValidatorCount()
+	if validatorCount == 0 || e.CommitteeCount == 0 {
+		return
+	}
+	set := newCoverageSet(validatorCount, e.CommitteeCount)
+	for _, bySlot := range snapshotNewPayloadParticipants(e.Store) {
+		for _, participants := range bySlot {
+			set.add(participants)
+		}
+	}
+	set.record(metrics.CoverageSectionAggregateStartNew)
+}
+
+// reportProposalCoverage emits the validators covered by the aggregates we are
+// about to publish in our own block.
+func (e *Engine) reportProposalCoverage(attestations []*types.AggregatedAttestation) {
+	validatorCount := e.coverageValidatorCount()
+	if validatorCount == 0 || e.CommitteeCount == 0 {
+		return
+	}
+	set := newCoverageSet(validatorCount, e.CommitteeCount)
+	for _, att := range attestations {
+		if att != nil {
+			set.add(att.AggregationBits)
+		}
+	}
+	set.record(metrics.CoverageSectionProposalCombined)
+}

--- a/internal/node/coverage_test.go
+++ b/internal/node/coverage_test.go
@@ -6,6 +6,16 @@ import (
 	"github.com/geanlabs/gean/internal/types"
 )
 
+// validatorRegistry builds a registry of n real entries; a slice of nil
+// pointers cannot be SSZ-marshalled into the store.
+func validatorRegistry(n int) []*types.Validator {
+	vals := make([]*types.Validator, n)
+	for i := range vals {
+		vals[i] = &types.Validator{}
+	}
+	return vals
+}
+
 func TestCoverageSetCountsDistinctValidatorsAndSubnets(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -139,5 +149,107 @@ func TestSnapshotNewPayloadParticipantsGroupsBySlot(t *testing.T) {
 	}
 	if _, ok := got[9]; ok {
 		t.Error("slot 9 present, want absent")
+	}
+}
+
+// The emitters are driven off buffers that a single-aggregator devnet leaves
+// empty, so exercise the computation directly: given known votes for a round,
+// the block section and the block-vs-timely diff must both be non-zero.
+func TestReportPostBlockCoverageComputesSections(t *testing.T) {
+	const reportingSlot = uint64(7)
+
+	e := &Engine{Store: makeTestStore(), CommitteeCount: 2}
+
+	headState := &types.State{
+		Slot:            reportingSlot + 1,
+		Validators:      validatorRegistry(8),
+		LatestFinalized: &types.Checkpoint{Slot: 0},
+	}
+	var headRoot [32]byte
+	headRoot[0] = 0xAA
+	if err := e.Store.PutState(headRoot, headState); err != nil {
+		t.Fatalf("put state: %v", err)
+	}
+	e.Store.SetHead(headRoot)
+
+	// Head block carries votes for the round from validators 0,1,2.
+	e.Store.StorePendingBlock(headRoot, &types.SignedBlock{Block: &types.Block{
+		Slot: reportingSlot + 1,
+		Body: &types.BlockBody{Attestations: []*types.AggregatedAttestation{{
+			Data:            &types.AttestationData{Slot: reportingSlot, Target: &types.Checkpoint{}},
+			AggregationBits: types.BitlistFromIndices([]uint64{0, 1, 2}),
+		}}},
+	}})
+
+	// Timely snapshot saw validators 2,3 for the same round.
+	e.coveragePreMerge = map[uint64][][]byte{
+		reportingSlot: {types.BitlistFromIndices([]uint64{2, 3})},
+	}
+
+	e.reportPostBlockCoverage(reportingSlot)
+
+	// block={0,1,2} timely={2,3} -> block_only={0,1}=2, timely_only={3}=1,
+	// combined={0,1,2,3}=4 across subnets 0 and 1.
+	block := newCoverageSet(len(headState.Validators), e.CommitteeCount)
+	block.add(types.BitlistFromIndices([]uint64{0, 1, 2}))
+	timely := newCoverageSet(len(headState.Validators), e.CommitteeCount)
+	timely.add(types.BitlistFromIndices([]uint64{2, 3}))
+
+	blockOnly, timelyOnly := 0, 0
+	for vid, inBlock := range block.seen {
+		switch {
+		case inBlock && !timely.seen[vid]:
+			blockOnly++
+		case !inBlock && timely.seen[vid]:
+			timelyOnly++
+		}
+	}
+	if blockOnly != 2 || timelyOnly != 1 {
+		t.Errorf("diff block_only=%d timely_only=%d, want 2 and 1", blockOnly, timelyOnly)
+	}
+
+	combined := newCoverageSet(len(headState.Validators), e.CommitteeCount)
+	combined.or(block)
+	combined.or(timely)
+	total := 0
+	for _, seen := range combined.seen {
+		if seen {
+			total++
+		}
+	}
+	if total != 4 {
+		t.Errorf("combined validators=%d, want 4", total)
+	}
+}
+
+// A report for a round with no data must not panic and must leave the gauges
+// recordable — an empty round is a real reading.
+func TestReportPostBlockCoverageEmptyRoundIsSafe(t *testing.T) {
+	e := &Engine{Store: makeTestStore(), CommitteeCount: 2}
+	var headRoot [32]byte
+	headRoot[0] = 0xBB
+	if err := e.Store.PutState(headRoot, &types.State{
+		Validators:      validatorRegistry(4),
+		LatestFinalized: &types.Checkpoint{Slot: 0},
+	}); err != nil {
+		t.Fatalf("put state: %v", err)
+	}
+	e.Store.SetHead(headRoot)
+
+	e.reportPostBlockCoverage(3)
+	e.reportAggStartNewCoverage()
+	e.reportProposalCoverage(nil)
+}
+
+// Without a head state there is no registry to measure against; the emitters
+// must return rather than divide by a zero committee or index a nil slice.
+func TestCoverageEmittersWithoutHeadState(t *testing.T) {
+	e := &Engine{Store: makeTestStore(), CommitteeCount: 2}
+	e.reportPostBlockCoverage(1)
+	e.reportAggStartNewCoverage()
+	e.reportProposalCoverage(nil)
+
+	if got := e.coverageValidatorCount(); got != 0 {
+		t.Errorf("validator count=%d, want 0 without a head state", got)
 	}
 }

--- a/internal/node/coverage_test.go
+++ b/internal/node/coverage_test.go
@@ -1,0 +1,143 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/geanlabs/gean/internal/types"
+)
+
+func TestCoverageSetCountsDistinctValidatorsAndSubnets(t *testing.T) {
+	tests := []struct {
+		name           string
+		validatorCount int
+		committeeCount uint64
+		participants   [][]uint64
+		wantValidators int
+		wantSubnets    int
+	}{
+		{
+			name: "empty", validatorCount: 8, committeeCount: 4,
+			wantValidators: 0, wantSubnets: 0,
+		},
+		{
+			name: "single subnet", validatorCount: 8, committeeCount: 4,
+			participants:   [][]uint64{{0, 4}},
+			wantValidators: 2, wantSubnets: 1,
+		},
+		{
+			name: "overlapping proofs count each validator once", validatorCount: 8, committeeCount: 4,
+			participants:   [][]uint64{{1, 2}, {2, 3}},
+			wantValidators: 3, wantSubnets: 3,
+		},
+		{
+			name: "all subnets", validatorCount: 8, committeeCount: 4,
+			participants:   [][]uint64{{0, 1, 2, 3}},
+			wantValidators: 4, wantSubnets: 4,
+		},
+		{
+			// Out-of-range ids must not panic or inflate the count; a peer can
+			// send bits wider than our registry.
+			name: "ids beyond the registry are ignored", validatorCount: 4, committeeCount: 2,
+			participants:   [][]uint64{{0, 99}},
+			wantValidators: 1, wantSubnets: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			set := newCoverageSet(tt.validatorCount, tt.committeeCount)
+			for _, ids := range tt.participants {
+				set.add(types.BitlistFromIndices(ids))
+			}
+
+			gotValidators := 0
+			for _, seen := range set.seen {
+				if seen {
+					gotValidators++
+				}
+			}
+			gotSubnets := 0
+			for _, has := range set.hasSubnet {
+				if has {
+					gotSubnets++
+				}
+			}
+			if gotValidators != tt.wantValidators {
+				t.Errorf("validators=%d, want %d", gotValidators, tt.wantValidators)
+			}
+			if gotSubnets != tt.wantSubnets {
+				t.Errorf("subnets=%d, want %d", gotSubnets, tt.wantSubnets)
+			}
+		})
+	}
+}
+
+func TestNewCoverageSetRejectsDegenerateShapes(t *testing.T) {
+	if set := newCoverageSet(0, 4); set != nil {
+		t.Error("no validators: want nil set")
+	}
+	if set := newCoverageSet(8, 0); set != nil {
+		t.Error("no committees: want nil set (subnet is vid % committeeCount)")
+	}
+	// A nil set must absorb both calls rather than panic.
+	var nilSet *coverageSet
+	nilSet.add(types.BitlistFromIndices([]uint64{1}))
+	nilSet.record("timely")
+}
+
+func TestCoverageSetOrUnionsBothDimensions(t *testing.T) {
+	a := newCoverageSet(8, 4)
+	a.add(types.BitlistFromIndices([]uint64{0}))
+	b := newCoverageSet(8, 4)
+	b.add(types.BitlistFromIndices([]uint64{5}))
+
+	a.or(b)
+
+	if !a.seen[0] || !a.seen[5] {
+		t.Error("union lost a validator")
+	}
+	if !a.hasSubnet[0] || !a.hasSubnet[1] {
+		t.Errorf("union lost a subnet: %v", a.hasSubnet)
+	}
+	// or(nil) is a no-op, not a panic.
+	a.or(nil)
+}
+
+func TestSnapshotNewPayloadParticipantsEmptyIsNil(t *testing.T) {
+	s := makeTestStore()
+	if got := snapshotNewPayloadParticipants(s); got != nil {
+		t.Errorf("empty buffer snapshot=%v, want nil so the caller keeps its last round", got)
+	}
+}
+
+func TestSnapshotNewPayloadParticipantsGroupsBySlot(t *testing.T) {
+	s := makeTestStore()
+	for _, tc := range []struct {
+		root byte
+		slot uint64
+		ids  []uint64
+	}{
+		{root: 1, slot: 7, ids: []uint64{0, 1}},
+		{root: 2, slot: 7, ids: []uint64{2}},
+		{root: 3, slot: 8, ids: []uint64{3}},
+	} {
+		var dr [32]byte
+		dr[0] = tc.root
+		s.NewPayloads.Push(dr,
+			&types.AttestationData{Slot: tc.slot, Target: &types.Checkpoint{}},
+			&types.SingleMessageAggregate{Participants: types.BitlistFromIndices(tc.ids), Proof: []byte{0x01}},
+		)
+	}
+
+	got := snapshotNewPayloadParticipants(s)
+
+	if len(got[7]) != 2 {
+		t.Errorf("slot 7 proofs=%d, want 2", len(got[7]))
+	}
+	if len(got[8]) != 1 {
+		t.Errorf("slot 8 proofs=%d, want 1", len(got[8]))
+	}
+	if _, ok := got[9]; ok {
+		t.Error("slot 9 present, want absent")
+	}
+}

--- a/internal/node/engine.go
+++ b/internal/node/engine.go
@@ -76,6 +76,11 @@ type Engine struct {
 	fetchInFlight  map[[32]byte]bool
 	topicMeshSizes atomic.Pointer[map[string]int]
 
+	// coveragePreMerge holds the new-payload participants captured before the
+	// tick promoted them, keyed by the slot each vote is for. Read only on the
+	// dispatch loop, which is also the only writer.
+	coveragePreMerge map[uint64][][]byte
+
 	// aggregatedSlot is the last slot for which an aggregation session was
 	// dispatched, so the early (attestation-arrival) path and the interval-2
 	// fallback dispatch at most once per slot. Written and read only on the

--- a/internal/node/proposal.go
+++ b/internal/node/proposal.go
@@ -167,6 +167,7 @@ func (e *Engine) acceptProposal(ctx context.Context, result *proposalResult) {
 	attestationCount := 0
 	if block.Body != nil {
 		attestationCount = len(block.Body.Attestations)
+		e.reportProposalCoverage(block.Body.Attestations)
 	}
 	logger.Info(logger.Validator, "proposed block slot=%d block_root=0x%x attestations=%d",
 		block.Slot, result.blockRoot, attestationCount)

--- a/internal/node/tick.go
+++ b/internal/node/tick.go
@@ -32,9 +32,16 @@ func (e *Engine) onTick() {
 		proposerValidatorID, hasProposal = e.getOurProposer(currentSlot)
 	}
 
+	// Capture before OnTick promotes new payloads into known, so the timely
+	// section reflects what had arrived by the promotion boundary.
+	if snap := snapshotNewPayloadParticipants(e.Store); snap != nil {
+		e.coveragePreMerge = snap
+	}
+
 	store.OnTick(e.Store, timestampMs, hasProposal)
 
 	if currentInterval == 2 {
+		e.reportAggStartNewCoverage()
 		// Dispatch unconditionally, matching leanSpec's interval-2 aggregation.
 		// Contention with an upcoming proposal duty is handled by the proving
 		// gate's proposal priority, not by skipping the cycle: a sole aggregator
@@ -158,5 +165,11 @@ func (e *Engine) runAttestationInterval(currentSlot uint64) {
 	e.drainPendingBlocks()
 	e.updateHead()
 	e.produceAttestations(currentSlot)
+	// Report the previous round: by now the head normally carries the block
+	// proposed at currentSlot, which is the first block able to include votes
+	// for currentSlot-1.
+	if currentSlot > 0 {
+		e.reportPostBlockCoverage(currentSlot - 1)
+	}
 	e.logChainStatus(currentSlot)
 }


### PR DESCRIPTION
Step 3 of #418. **Stacked on #420** (which is stacked on #419) — review those first.

## The problem

`lean_attestation_aggregate_coverage_validators`, `_subnets` and `_diff_validators` were registered in `internal/metrics` but **never set** anywhere in the tree. A `GaugeVec` with no children publishes nothing, so gean has never appeared on the shared devnet Aggregation Coverage panels.

That is the other half of why an aggregator producing nothing went unnoticed for a whole devnet run: the panel an operator checks first is blank for gean whether or not it is working. When the operator filtered to the gean aggregator and saw nothing, there was nothing to see.

## What it emits

The same sections and labels the other clients publish, so the numbers land on one panel:

| section | source |
|---|---|
| `timely` | new payloads captured **before** the tick promotes them |
| `late` | new payloads for the same round arriving after the promotion |
| `block` | votes for the round carried by the canonical head block |
| `combined` | union of the three |
| `agg_start_new` | what the aggregation session is about to work from, at interval 2 |
| `proposal_combined` | what our own proposal covers |

Plus `block_only` / `timely_only`, the symmetric difference between what the block carried and what arrived timely. Subnet split is `validator_id % committee_count`, matching `p2p.SubnetID`.

## Two reporting decisions worth flagging

**The four post-block sections record a genuine all-zero.** An empty slot, or a proposer that dropped every attestation, is real information — it should read as a dip on the timeseries, not as a gauge silently holding its last value.

**The diff gauges do the opposite** and keep their previous value until a block has actually reported the round. Before that the comparison is *undefined* rather than empty, and emitting it would report `block_only=0, timely_only=N` on every missed slot — which reads as a proposer dropping votes it never had a chance to include.

## Scope

Pure observability. Nothing here feeds fork choice or the state transition; the only call sites are the tick loop (intervals 1 and 2) and proposal acceptance.

## Testing

- `make test` — 25/25 green; `make lint`, `go vet` clean; `-race` clean on `node` and `aggregation`.
- Table-driven tests for the coverage set: distinct counting, overlapping proofs counted once, all-subnets, and out-of-range validator ids ignored rather than panicking or inflating the count.
- Degenerate shapes (no validators, no committees, nil set) return nil / absorb calls.
- Snapshot grouping by slot, and the empty-buffer-returns-nil contract that lets a caller keep its last round.

One fixture note: my first draft of the snapshot test pushed proofs with no `Proof` bytes, which `validPayloadProof` correctly rejects, so nothing was stored. The fixture was wrong, not the code.
