### PR TITLE
fix(node,store): take the full-table scans off the dispatch loop and repair finalization pruning

### DIFF
--- a/cmd/gean/main.go
+++ b/cmd/gean/main.go
@@ -109,9 +109,10 @@ func run(cfg config) error {
 
 	waitForShutdown(cancel)
 
-	// Join the background goroutines that read storage before the deferred
-	// backend.Close runs. Cancellation alone is not enough: a sampler mid-round
-	// when the database closes calls into a closed Pebble instance, which panics.
+	// Join the storage-size sampler before the deferred backend.Close runs.
+	// Cancellation alone is not enough: a sampler mid-round when the database
+	// closes calls into a closed Pebble instance, which panics. Other workers
+	// that read storage are still not joined — a pre-existing gap.
 	n.WaitForStorageWorkers()
 	return nil
 }

--- a/cmd/gean/main.go
+++ b/cmd/gean/main.go
@@ -63,6 +63,15 @@ func run(cfg config) error {
 		return err
 	}
 
+	// Recover the stored-block high-water mark before any duty runs. Doing it
+	// here rather than lazily keeps the full-table scan off the dispatch loop
+	// entirely, and surfaces a read failure at startup instead of leaving the
+	// duty gate to act on an understated mark.
+	if err := s.SeedMaxStoredBlockSlot(); err != nil {
+		logger.Error(logger.Node, "seed max stored block slot: %v", err)
+		return err
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -99,5 +108,10 @@ func run(cfg config) error {
 	logger.Info(logger.Node, "gean started: api=%s metrics=%s aggregator=%v", apiAddr, metricsAddr, cfg.IsAggregator)
 
 	waitForShutdown(cancel)
+
+	// Join the background goroutines that read storage before the deferred
+	// backend.Close runs. Cancellation alone is not enough: a sampler mid-round
+	// when the database closes calls into a closed Pebble instance, which panics.
+	n.WaitForStorageWorkers()
 	return nil
 }

--- a/internal/blockbuilder/build_test.go
+++ b/internal/blockbuilder/build_test.go
@@ -178,7 +178,7 @@ func TestBuildBlockReportsMismatchedPayloadRoot(t *testing.T) {
 		Slot:            1,
 		ProposerIndex:   0,
 		ParentRoot:      parentRoot,
-		KnownBlockRoots: map[[32]byte]bool{parentRoot: true},
+		KnownBlockRoots: RootSet{parentRoot: true},
 		Payloads: []AttestationPayload{{
 			DataRoot: [32]byte{0xee},
 			Data:     data,
@@ -218,7 +218,7 @@ func TestBuildBlockReportsSkippedPayloadIssues(t *testing.T) {
 		Slot:            3,
 		ProposerIndex:   0,
 		ParentRoot:      parentRoot,
-		KnownBlockRoots: map[[32]byte]bool{parentRoot: true},
+		KnownBlockRoots: RootSet{parentRoot: true},
 		Payloads: []AttestationPayload{
 			{DataRoot: dataRoot, Data: data, Proofs: []*types.SingleMessageAggregate{mockProof([]uint64{0})}},
 			{DataRoot: staleRoot, Data: &staleSourceVote, Proofs: []*types.SingleMessageAggregate{mockProof([]uint64{0})}},
@@ -255,7 +255,7 @@ func TestBuildBlockRecordsProofMergeFallback(t *testing.T) {
 		Slot:            3,
 		ProposerIndex:   0,
 		ParentRoot:      parentRoot,
-		KnownBlockRoots: map[[32]byte]bool{parentRoot: true},
+		KnownBlockRoots: RootSet{parentRoot: true},
 		Payloads: []AttestationPayload{{
 			DataRoot: dataRoot,
 			Data:     data,
@@ -290,7 +290,7 @@ func TestPlanAttestationsUsesPostHeaderState(t *testing.T) {
 		Slot:            3,
 		ProposerIndex:   0,
 		ParentRoot:      parentRoot,
-		KnownBlockRoots: map[[32]byte]bool{parentRoot: true},
+		KnownBlockRoots: RootSet{parentRoot: true},
 		Payloads: []AttestationPayload{{
 			DataRoot: dataRoot,
 			Data:     data,
@@ -358,7 +358,7 @@ func TestPlanAttestationsCarriesTrialState(t *testing.T) {
 		Slot:            3,
 		ProposerIndex:   0,
 		ParentRoot:      parentRoot,
-		KnownBlockRoots: map[[32]byte]bool{root1: true, parentRoot: true},
+		KnownBlockRoots: RootSet{root1: true, parentRoot: true},
 		Payloads: []AttestationPayload{
 			{DataRoot: firstRoot, Data: first, Proofs: []*types.SingleMessageAggregate{mockProof([]uint64{0})}},
 			{DataRoot: secondRoot, Data: second, Proofs: []*types.SingleMessageAggregate{mockProof([]uint64{0})}},
@@ -426,7 +426,7 @@ func TestPlanAttestationsContinuesWhenJustifiedSlotsChange(t *testing.T) {
 		Slot:            7,
 		ProposerIndex:   0,
 		ParentRoot:      parentRoot,
-		KnownBlockRoots: map[[32]byte]bool{roots[2]: true, parentRoot: true},
+		KnownBlockRoots: RootSet{roots[2]: true, parentRoot: true},
 		Payloads: []AttestationPayload{
 			{DataRoot: firstRoot, Data: first, Proofs: []*types.SingleMessageAggregate{mockProof([]uint64{0})}},
 			{DataRoot: secondRoot, Data: second, Proofs: []*types.SingleMessageAggregate{mockProof([]uint64{0})}},
@@ -502,7 +502,7 @@ func TestPlanAttestationsDoesNotReportSkippedPayloadsWhenFull(t *testing.T) {
 		Slot:            2,
 		ProposerIndex:   0,
 		ParentRoot:      parentRoot,
-		KnownBlockRoots: map[[32]byte]bool{parentRoot: true},
+		KnownBlockRoots: RootSet{parentRoot: true},
 		Payloads:        payloads,
 	})
 	if err != nil {

--- a/internal/blockbuilder/model.go
+++ b/internal/blockbuilder/model.go
@@ -11,10 +11,31 @@ type AttestationPayload struct {
 	Proofs   []*types.SingleMessageAggregate
 }
 
-type KnownRoots map[[32]byte]bool
+// KnownRoots answers whether a block root is one this node has stored.
+//
+// The builder only ever asks membership, a handful of times per proposal, so
+// this is a predicate rather than a set. It used to be a map that the proposal
+// path filled by scanning every key in TableBlockHeaders and allocating an
+// entry per root — tens of thousands of them on a mature chain, rebuilt for
+// every block produced, on the tick loop.
+type KnownRoots interface {
+	Contains(root [32]byte) bool
+}
 
-func (roots KnownRoots) Contains(root [32]byte) bool {
+// RootSet is the in-memory implementation, used by tests and by any caller that
+// genuinely holds the whole set already.
+type RootSet map[[32]byte]bool
+
+func (roots RootSet) Contains(root [32]byte) bool {
 	return roots[root]
+}
+
+// KnownRootsFunc adapts a plain lookup — a point read against storage, say —
+// into a KnownRoots.
+type KnownRootsFunc func(root [32]byte) bool
+
+func (f KnownRootsFunc) Contains(root [32]byte) bool {
+	return f(root)
 }
 
 type Input struct {

--- a/internal/blockbuilder/payloads.go
+++ b/internal/blockbuilder/payloads.go
@@ -78,7 +78,11 @@ func validatePayload(payload AttestationPayload) error {
 
 func payloadBuildIssue(state *types.State, knownRoots KnownRoots, payload AttestationPayload) error {
 	data := payload.Data
-	if !knownRoots.Contains(data.Head.Root) {
+	// A nil KnownRoots knows nothing, matching the nil-map behaviour this
+	// replaced. validateInput already rejects nil whenever there are payloads to
+	// build, so this is the belt to that braces — but an interface, unlike a map,
+	// panics rather than returning false when nil, so it has to be explicit.
+	if knownRoots == nil || !knownRoots.Contains(data.Head.Root) {
 		return errPayloadHeadUnknown(data.Head.Root)
 	}
 	// Only source votes from the chain's current justified checkpoint: older sources

--- a/internal/blockbuilder/payloads_test.go
+++ b/internal/blockbuilder/payloads_test.go
@@ -188,7 +188,7 @@ func TestPayloadBuildIssueUsesTransitionVoteRules(t *testing.T) {
 		Data:     data,
 		Proofs:   []*types.SingleMessageAggregate{mockProof([]uint64{0})},
 	}
-	knownRoots := map[[32]byte]bool{parentRoot: true}
+	knownRoots := RootSet{parentRoot: true}
 	if err := payloadBuildIssue(workingState, knownRoots, payload); err != nil {
 		t.Fatalf("expected payload to be buildable, got %v", err)
 	}
@@ -204,7 +204,7 @@ func TestPayloadBuildIssueUsesTransitionVoteRules(t *testing.T) {
 	offHead := *data
 	forkHead := [32]byte{0xfe}
 	offHead.Head = &types.Checkpoint{Slot: data.Head.Slot, Root: forkHead}
-	if err := payloadBuildIssue(workingState, map[[32]byte]bool{parentRoot: true, forkHead: true},
+	if err := payloadBuildIssue(workingState, RootSet{parentRoot: true, forkHead: true},
 		AttestationPayload{DataRoot: dataRoot, Data: &offHead, Proofs: payload.Proofs}); !errors.Is(err, ErrPayloadHeadOffChain) {
 		t.Fatalf("payload build issue=%v, want ErrPayloadHeadOffChain", err)
 	} else if !IsExpectedSkip(err) {
@@ -279,7 +279,7 @@ func TestPayloadBuildIssueSkipsStaleSource(t *testing.T) {
 		Data:     &staleSource,
 		Proofs:   []*types.SingleMessageAggregate{mockProof([]uint64{0})},
 	}
-	err = payloadBuildIssue(workingState, map[[32]byte]bool{parentRoot: true}, payload)
+	err = payloadBuildIssue(workingState, RootSet{parentRoot: true}, payload)
 	if !errors.Is(err, ErrPayloadSourceNotCurrentJustified) {
 		t.Fatalf("payload build issue=%v, want ErrPayloadSourceNotCurrentJustified", err)
 	}
@@ -301,7 +301,7 @@ func TestPayloadBuildIssueAllowsGenesisSelfVote(t *testing.T) {
 		Target: &types.Checkpoint{Root: root},
 	}
 	dataRoot := hashAttestationData(t, data)
-	err := payloadBuildIssue(state, map[[32]byte]bool{root: true}, AttestationPayload{
+	err := payloadBuildIssue(state, RootSet{root: true}, AttestationPayload{
 		DataRoot: dataRoot,
 		Data:     data,
 		Proofs:   []*types.SingleMessageAggregate{mockProof([]uint64{0})},

--- a/internal/blockprocessor/persist.go
+++ b/internal/blockprocessor/persist.go
@@ -90,6 +90,10 @@ func persistBlock(
 	if err := wb.Commit(); err != nil {
 		return fmt.Errorf("persist block: commit: %w", err)
 	}
+	// The header is now stored, so the duty gate's stored-block high-water mark
+	// has to see it. This is the import path's equivalent of what
+	// ConsensusStore.PutBlockHeader does for pending blocks.
+	s.ObserveStoredBlockSlot(block.Slot)
 	return nil
 }
 

--- a/internal/metrics/gauges.go
+++ b/internal/metrics/gauges.go
@@ -12,6 +12,14 @@ var (
 	metricCurrentSlot = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "lean_current_slot", Help: "Current slot from wall clock",
 	})
+	// metricTickAge is the stall detector. lean_tick_interval_duration_seconds is
+	// a histogram observed *inside* onTick, so it records nothing at all while the
+	// dispatch loop is blocked — the failure it should report makes it go quiet
+	// rather than spike, and its top bucket is 1.6s besides. This gauge is written
+	// from a separate goroutine and keeps climbing for as long as the loop is stuck.
+	metricTickAge = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "lean_tick_last_age_seconds", Help: "Seconds since the dispatch loop last began a tick",
+	})
 	metricSafeTargetSlot = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "lean_safe_target_slot", Help: "Safe target slot for attestation",
 	})

--- a/internal/metrics/histograms.go
+++ b/internal/metrics/histograms.go
@@ -121,6 +121,15 @@ var (
 		Help:    "Elapsed time between clock ticks in seconds",
 		Buckets: []float64{0.4, 0.6, 0.75, 0.8, 0.805, 0.81, 0.815, 0.82, 0.825, 0.85, 0.9, 1.0, 1.2, 1.6},
 	})
+	// metricDispatchEventDuration times each case of the dispatch select, so a
+	// slow handler can be attributed rather than only observed as a late tick.
+	// Buckets run well past a slot: the point is to size a stall, and the
+	// tick-interval histogram's 1.6s ceiling could not.
+	metricDispatchEventDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "lean_dispatch_event_duration_seconds",
+		Help:    "Time the dispatch loop spent handling one event, by event kind",
+		Buckets: []float64{0.001, 0.01, 0.05, 0.1, 0.25, 0.5, 0.8, 1.6, 4, 10, 30, 120, 600},
+	}, []string{"event"})
 	metricProvingDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "lean_proving_duration_seconds",
 		Help:    "Recursive proof operation duration",

--- a/internal/metrics/labels.go
+++ b/internal/metrics/labels.go
@@ -9,7 +9,6 @@ var syncStatusLabels = []string{"idle", "syncing", "synced", unknownLabel}
 
 const (
 	AggregatorSkipNotAggregator = "not_aggregator"
-	AggregatorSkipNotSynced     = "not_synced"
 	AggregatorSkipMissingState  = "missing_state"
 	AggregatorSkipSpawnFailed   = "spawn_failed"
 	AggregatorSkipOther         = "other"
@@ -17,7 +16,6 @@ const (
 
 var aggregatorSkipReasons = []string{
 	AggregatorSkipNotAggregator,
-	AggregatorSkipNotSynced,
 	AggregatorSkipMissingState,
 	AggregatorSkipSpawnFailed,
 	AggregatorSkipOther,

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -27,7 +27,6 @@ func TestCountCounterWrappersIgnoreNonPositiveValues(t *testing.T) {
 func TestIncAggregatorSkippedUsesBoundedReasons(t *testing.T) {
 	reasons := []string{
 		AggregatorSkipNotAggregator,
-		AggregatorSkipNotSynced,
 		AggregatorSkipMissingState,
 		AggregatorSkipSpawnFailed,
 		AggregatorSkipOther,

--- a/internal/metrics/observe.go
+++ b/internal/metrics/observe.go
@@ -25,6 +25,15 @@ func ObserveForkChoiceReorgDepth(depth float64) {
 func ObserveTickIntervalDuration(seconds float64) {
 	observeNonNegative(metricTickIntervalDuration, seconds)
 }
+
+// ObserveDispatchEvent records how long one dispatch-loop event took.
+func ObserveDispatchEvent(event string, seconds float64) {
+	if seconds < 0 {
+		return
+	}
+	metricDispatchEventDuration.WithLabelValues(event).Observe(seconds)
+}
+
 func ObserveSTFTime(seconds float64)      { observeNonNegative(metricSTFTime, seconds) }
 func ObserveSTFSlotsTime(seconds float64) { observeNonNegative(metricSTFSlotsTime, seconds) }
 func ObserveSTFBlockTime(seconds float64) { observeNonNegative(metricSTFBlockTime, seconds) }

--- a/internal/metrics/set.go
+++ b/internal/metrics/set.go
@@ -6,6 +6,7 @@ func SetNodeInfo(name, version string) {
 func SetNodeStartTime(t float64)      { setNonNegative(metricNodeStartTime, t) }
 func SetHeadSlot(s uint64)            { metricHeadSlot.Set(float64(s)) }
 func SetCurrentSlot(s uint64)         { metricCurrentSlot.Set(float64(s)) }
+func SetTickAge(seconds float64)      { metricTickAge.Set(seconds) }
 func SetSafeTargetSlot(s uint64)      { metricSafeTargetSlot.Set(float64(s)) }
 func SetLatestJustifiedSlot(s uint64) { metricLatestJustifiedSlot.Set(float64(s)) }
 func SetLatestFinalizedSlot(s uint64) { metricLatestFinalizedSlot.Set(float64(s)) }

--- a/internal/node/dispatch.go
+++ b/internal/node/dispatch.go
@@ -5,7 +5,18 @@ import (
 	"time"
 
 	"github.com/geanlabs/gean/internal/logger"
+	"github.com/geanlabs/gean/internal/metrics"
 )
+
+// timeEvent records how long one dispatch-loop event took. Every case runs on
+// the single goroutine that also keeps the slot clock, so an unattributed slow
+// handler here shows up only as a late tick — which is exactly how a set of
+// full-table storage scans went unnoticed until they were costing minutes.
+func timeEvent(event string, fn func()) {
+	start := time.Now()
+	fn()
+	metrics.ObserveDispatchEvent(event, time.Since(start).Seconds())
+}
 
 func (e *Engine) dispatch(ctx context.Context, ticks <-chan time.Time) {
 	for {
@@ -15,19 +26,19 @@ func (e *Engine) dispatch(ctx context.Context, ticks <-chan time.Time) {
 			return
 
 		case <-ticks:
-			e.onTick()
+			timeEvent("tick", e.onTick)
 
 		case <-e.EarlyAggregateCh:
-			e.maybeEarlyAggregate(uint64(time.Now().UnixMilli()))
+			timeEvent("early_aggregate", func() { e.maybeEarlyAggregate(uint64(time.Now().UnixMilli())) })
 
 		case block := <-e.BlockCh:
-			e.onBlock(block)
+			timeEvent("block", func() { e.onBlock(block) })
 
 		case result := <-e.ProposalResultCh:
-			e.acceptProposal(ctx, result)
+			timeEvent("proposal_result", func() { e.acceptProposal(ctx, result) })
 
 		case root := <-e.FailedRootCh:
-			e.onFailedRoot(root)
+			timeEvent("failed_root", func() { e.onFailedRoot(root) })
 		}
 	}
 }

--- a/internal/node/engine.go
+++ b/internal/node/engine.go
@@ -70,6 +70,10 @@ type Engine struct {
 
 	lastTick time.Time
 
+	// lastTickMs mirrors lastTick for the stall sampler, which runs on its own
+	// goroutine precisely so it still reports while the dispatch loop is blocked.
+	lastTickMs atomic.Int64
+
 	warnedMissingJustified [32]byte
 
 	// maxSeenGossipSlot is the highest plausible slot heard on gossip, whether

--- a/internal/node/engine.go
+++ b/internal/node/engine.go
@@ -69,10 +69,16 @@ type Engine struct {
 	RecoveryCh            chan *types.SignedBlock
 	ProvingGate           *proving.Gate
 
-	// storageWorkers tracks the background goroutines that touch the storage
-	// backend, so shutdown can join them before the database is closed. A
-	// sampler still running after Close calls into a closed Pebble instance,
-	// which panics rather than erroring.
+	// storageWorkers tracks the storage-size sampler so shutdown can join it
+	// before the database is closed: a sampler still running after Close calls
+	// into a closed Pebble instance, which panics rather than erroring.
+	//
+	// Scope is deliberately narrow. Other workers read storage too — the
+	// aggregation, proposal, recovery and attestation workers, and the fetch
+	// batcher — and none of them is joined either. That is a pre-existing
+	// shutdown weakness, not one this sampler introduced, and closing it means
+	// deciding how long shutdown may block on in-flight proving work. Tracked
+	// separately; do not read this WaitGroup as covering them.
 	storageWorkers sync.WaitGroup
 
 	lastTick time.Time
@@ -153,9 +159,12 @@ func New(
 	return e
 }
 
-// WaitForStorageWorkers blocks until every background goroutine that reads the
-// storage backend has returned. Callers must invoke it after cancelling the
-// context and before closing the backend.
+// WaitForStorageWorkers blocks until the storage-size sampler has returned.
+// Callers must invoke it after cancelling the context and before closing the
+// backend.
+//
+// It does not cover every storage-reading goroutine — see the storageWorkers
+// field for what is and is not tracked.
 func (e *Engine) WaitForStorageWorkers() {
 	e.storageWorkers.Wait()
 }

--- a/internal/node/engine.go
+++ b/internal/node/engine.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -67,6 +68,12 @@ type Engine struct {
 	ProposalResultCh      chan *proposalResult
 	RecoveryCh            chan *types.SignedBlock
 	ProvingGate           *proving.Gate
+
+	// storageWorkers tracks the background goroutines that touch the storage
+	// backend, so shutdown can join them before the database is closed. A
+	// sampler still running after Close calls into a closed Pebble instance,
+	// which panics rather than erroring.
+	storageWorkers sync.WaitGroup
 
 	lastTick time.Time
 
@@ -144,6 +151,13 @@ func New(
 	}
 	e.configureP2PHooks()
 	return e
+}
+
+// WaitForStorageWorkers blocks until every background goroutine that reads the
+// storage backend has returned. Callers must invoke it after cancelling the
+// context and before closing the backend.
+func (e *Engine) WaitForStorageWorkers() {
+	e.storageWorkers.Wait()
 }
 
 func (e *Engine) Run(ctx context.Context) {

--- a/internal/node/finalization_prune_test.go
+++ b/internal/node/finalization_prune_test.go
@@ -1,0 +1,80 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/geanlabs/gean/internal/types"
+)
+
+// Finalization pruning is the only thing that shrinks TableStates and
+// TableBlockHeaders, and it reads its delete list from fork choice. For a long
+// time it deleted nothing at all: updateFinalizedFromHead pruned the ProtoArray
+// before calling PruneOnFinalization, so GetCanonicalAnalysis ran against an
+// array that no longer held the ancestors or the losing branches and returned
+// two empty lists. Nothing failed, nothing logged, and the two tables grew for
+// the life of the chain — which is what made the per-slot full-table scans on
+// the dispatch loop expensive enough to stall the slot clock.
+//
+// The shape here is: genesis -> a(1) -> b(2) -> c(3), with a losing fork x(2)
+// off a. Finalizing b must drop x entirely and drop a's state, while keeping
+// the finalized block's own state and everything above it.
+func TestFinalizationPrunesAncestorAndLosingBranch(t *testing.T) {
+	e := makeTestEngine()
+
+	genesis := [32]byte{0x01}
+	rootA := [32]byte{0x0a}
+	rootB := [32]byte{0x0b}
+	rootC := [32]byte{0x0c}
+	rootX := [32]byte{0x0f}
+
+	// finalizedIn is the checkpoint a block's post-state carries.
+	add := func(root, parent [32]byte, slot uint64, finalizedIn *types.Checkpoint) {
+		e.Store.InsertBlockHeader(root, &types.BlockHeader{Slot: slot, ParentRoot: parent})
+		e.Store.InsertState(root, &types.State{
+			Slot:                     slot,
+			LatestBlockHeader:        &types.BlockHeader{Slot: slot, ParentRoot: parent},
+			LatestJustified:          &types.Checkpoint{Root: genesis, Slot: 0},
+			LatestFinalized:          finalizedIn,
+			JustifiedSlots:           types.NewBitlistSSZ(0),
+			JustificationsValidators: types.NewBitlistSSZ(0),
+		})
+		e.FC.OnBlock(slot, root, parent)
+	}
+
+	genesisCP := &types.Checkpoint{Root: genesis, Slot: 0}
+	add(rootA, genesis, 1, genesisCP)
+	add(rootX, rootA, 2, genesisCP)
+	add(rootB, rootA, 2, genesisCP)
+	// c's post-state is what drives finalization: it finalizes b at slot 2.
+	add(rootC, rootB, 3, &types.Checkpoint{Root: rootB, Slot: 2})
+
+	e.Store.SetHead(rootC)
+	e.updateFinalizedFromHead(rootC)
+
+	if got := e.Store.LatestFinalized(); got == nil || got.Slot != 2 || got.Root != rootB {
+		t.Fatalf("finalized checkpoint = %+v, want slot 2 root %x", got, rootB)
+	}
+
+	// The losing branch goes entirely: state and block header both.
+	if e.Store.HasState(rootX) {
+		t.Error("losing branch state survived finalization pruning")
+	}
+	if e.Store.GetBlockHeader(rootX) != nil {
+		t.Error("losing branch block header survived finalization pruning")
+	}
+
+	// Ancestors below the finalized root keep their headers but lose their
+	// states — canonical[1:] in PruneOnFinalization.
+	if e.Store.HasState(rootA) {
+		t.Error("ancestor state below the finalized root survived finalization pruning")
+	}
+
+	// The finalized block and the head above it must be untouched: without
+	// their states the node cannot run a transition from the finalized anchor.
+	if !e.Store.HasState(rootB) {
+		t.Error("finalized block state was pruned")
+	}
+	if !e.Store.HasState(rootC) {
+		t.Error("head state was pruned")
+	}
+}

--- a/internal/node/head.go
+++ b/internal/node/head.go
@@ -99,10 +99,18 @@ func (e *Engine) updateFinalizedFromHead(headRoot [32]byte) {
 	if derived.Slot > oldSlot {
 		metrics.IncFinalization("success")
 		logger.Info(logger.Forkchoice, "finalized advanced slot=%d root=0x%x", derived.Slot, derived.Root)
+		// Order matters and is not interchangeable. PruneOnFinalization asks fork
+		// choice which roots to delete (GetCanonicalAnalysis: the ancestors below
+		// the new finalized root, and every branch that is neither ancestor nor
+		// descendant of it). FC.Prune removes exactly those nodes from the
+		// ProtoArray. Pruning fork choice first therefore leaves the analysis with
+		// nothing to report — canonical is length 1 so canonical[1:] is empty, and
+		// nonCanonical is empty — so the database prune silently deletes nothing
+		// and TableStates/TableBlockHeaders grow for the life of the chain.
+		store.PruneOnFinalization(e.Store, e.FC, oldSlot, derived.Slot, derived.Root)
 		if derived.Slot > 0 {
 			e.FC.Prune(derived.Root)
 		}
-		store.PruneOnFinalization(e.Store, e.FC, oldSlot, derived.Slot, derived.Root)
 		e.discardFinalizedPending(derived.Slot)
 	}
 }

--- a/internal/node/import.go
+++ b/internal/node/import.go
@@ -1,6 +1,8 @@
 package node
 
 import (
+	"context"
+
 	"github.com/geanlabs/gean/internal/blockprocessor"
 	"github.com/geanlabs/gean/internal/logger"
 	"github.com/geanlabs/gean/internal/metrics"
@@ -91,11 +93,17 @@ func (e *Engine) importKnownParentBlock(
 // goroutine, so the cost landed directly on the slot clock. A storage-size gauge
 // is coarse by nature and does not need per-block resolution; it is sampled on
 // its own goroutine now, like the gossip-mesh gauge.
-func (e *Engine) recordTableBytes() {
+func (e *Engine) recordTableBytes(ctx context.Context) {
 	if e.Store == nil || e.Store.Backend == nil {
 		return
 	}
 	for _, table := range storage.AllTables {
+		// Bail between tables so a cancelled shutdown does not spend a whole
+		// round on a database that is about to close. Responsiveness only:
+		// Engine.WaitForStorageWorkers is what actually makes Close safe.
+		if ctx.Err() != nil {
+			return
+		}
 		metrics.SetTableBytes(string(table), e.Store.Backend.EstimateTableBytes(table))
 	}
 }

--- a/internal/node/import.go
+++ b/internal/node/import.go
@@ -76,7 +76,6 @@ func (e *Engine) importKnownParentBlock(
 	e.dispatchRecovery(signedBlock)
 
 	e.FC.OnBlock(block.Slot, blockRoot, parentRoot)
-	e.recordTableBytes()
 
 	e.updateHead()
 	e.Pending.ClearDepth(blockRoot)
@@ -84,9 +83,14 @@ func (e *Engine) importKnownParentBlock(
 	e.collectPendingChildren(blockRoot, queue)
 }
 
-// recordTableBytes refreshes the per-table storage-size gauge after a block is
-// persisted. Runs on the single-threaded import path, so the estimate reflects
-// the just-applied write with no locking concerns.
+// recordTableBytes refreshes the per-table storage-size gauge.
+//
+// This used to run on the import path, once per block. Both halves of that were
+// wrong: the backend estimate was a full scan of every table (see
+// storage.PebbleBackend.EstimateTableBytes), and the import path is the dispatch
+// goroutine, so the cost landed directly on the slot clock. A storage-size gauge
+// is coarse by nature and does not need per-block resolution; it is sampled on
+// its own goroutine now, like the gossip-mesh gauge.
 func (e *Engine) recordTableBytes() {
 	if e.Store == nil || e.Store.Backend == nil {
 		return

--- a/internal/node/proposal.go
+++ b/internal/node/proposal.go
@@ -248,18 +248,12 @@ func (e *Engine) produceBlockWithSignatures(slot, validatorIndex uint64) (*types
 		return nil, nil, fmt.Errorf("validator %d not proposer for slot %d", validatorIndex, slot)
 	}
 
-	knownBlockRoots, err := e.Store.BlockRoots()
-	if err != nil {
-		metrics.IncBlockBuildingFailures()
-		return nil, nil, fmt.Errorf("load block roots: %w", err)
-	}
-
 	result, err := blockbuilder.Build(blockbuilder.Input{
 		HeadState:       headState,
 		Slot:            slot,
 		ProposerIndex:   validatorIndex,
 		ParentRoot:      headRoot,
-		KnownBlockRoots: knownBlockRoots,
+		KnownBlockRoots: blockbuilder.KnownRootsFunc(e.Store.HasBlockHeader),
 		Payloads:        payloadsFromEntries(e.Store.KnownPayloads.Entries()),
 		ProofMerger:     attestationproof.NewMerger(e.Store.PubKeyCache),
 	})

--- a/internal/node/status.go
+++ b/internal/node/status.go
@@ -17,6 +17,14 @@ const SyncLagSlots = 2
 // sample, not a control input, so it runs well below the slot cadence.
 const gossipMeshSampleInterval = 10 * time.Second
 
+// tickAgeSampleInterval paces the stall detector. A slot is 4s, so a second is
+// fine-grained enough to distinguish a slow tick from a stopped loop.
+const tickAgeSampleInterval = time.Second
+
+// storageSizeSampleInterval paces the per-table storage-size gauge. Table sizes
+// move on compaction and pruning, not per block, so a minute is ample.
+const storageSizeSampleInterval = time.Minute
+
 func (e *Engine) updateSyncStatus(currentSlot uint64) {
 	status := e.computeSyncStatus(currentSlot)
 	metrics.SetSyncStatus(status.String())
@@ -65,7 +73,6 @@ func (e *Engine) logChainStatus(currentSlot uint64) {
 
 	gossipSigs := e.Store.AttestationSignatures.Len()
 	knownPayloads := e.Store.KnownPayloads.Len()
-	statesCount := e.Store.StatesCount()
 	fcNodesCount := 0
 	if e.FC != nil {
 		fcNodesCount = e.FC.Len()
@@ -80,13 +87,13 @@ func (e *Engine) logChainStatus(currentSlot uint64) {
 		}
 	}
 
-	logger.Info(logger.Chain, "\n\n+===============================================================+\n  CHAIN STATUS: Current Slot: %d | Head Slot: %d | Behind: %d\n+---------------------------------------------------------------+\n  Connected Peers:    %d\n+---------------------------------------------------------------+\n  Head Block Root:    0x%x\n  Parent Block Root:  0x%x\n  State Root:         0x%x\n+---------------------------------------------------------------+\n  Latest Justified:   Slot %6d | Root: 0x%x\n  Latest Finalized:   Slot %6d | Root: 0x%x\n+---------------------------------------------------------------+\n  Gossip Sigs: %d | Known Payloads: %d | States: %d | FC Nodes: %d\n+---------------------------------------------------------------+\n  Topics:%s\n+===============================================================+\n",
+	logger.Info(logger.Chain, "\n\n+===============================================================+\n  CHAIN STATUS: Current Slot: %d | Head Slot: %d | Behind: %d\n+---------------------------------------------------------------+\n  Connected Peers:    %d\n+---------------------------------------------------------------+\n  Head Block Root:    0x%x\n  Parent Block Root:  0x%x\n  State Root:         0x%x\n+---------------------------------------------------------------+\n  Latest Justified:   Slot %6d | Root: 0x%x\n  Latest Finalized:   Slot %6d | Root: 0x%x\n+---------------------------------------------------------------+\n  Gossip Sigs: %d | Known Payloads: %d | FC Nodes: %d\n+---------------------------------------------------------------+\n  Topics:%s\n+===============================================================+\n",
 		currentSlot, headSlot, behind,
 		peerCount,
 		headRoot, parentRoot, stateRoot,
 		justified.Slot, justified.Root,
 		finalized.Slot, finalized.Root,
-		gossipSigs, knownPayloads, statesCount, fcNodesCount,
+		gossipSigs, knownPayloads, fcNodesCount,
 		meshInfo)
 }
 
@@ -108,6 +115,51 @@ func (e *Engine) runGossipMeshGauge(ctx context.Context) {
 			return
 		case <-ticker.C:
 			e.sampleGossipMesh()
+		}
+	}
+}
+
+// runTickAgeGauge publishes how long it has been since the dispatch loop last
+// began a tick. It must live off that loop: the existing tick-interval histogram
+// is observed inside onTick, so a fully blocked loop produces no observations at
+// all and the metric goes silent exactly when it should be alarming.
+func (e *Engine) runTickAgeGauge(ctx context.Context) {
+	ticker := time.NewTicker(tickAgeSampleInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			last := e.lastTickMs.Load()
+			if last == 0 {
+				continue
+			}
+			age := time.Since(time.UnixMilli(last)).Seconds()
+			if age < 0 {
+				age = 0
+			}
+			metrics.SetTickAge(age)
+		}
+	}
+}
+
+// runStorageSizeGauge samples the per-table storage-size gauge off the tick
+// loop. Even with a metadata-based estimate this is not work the dispatch
+// goroutine should carry, and a size gauge loses nothing to a slow cadence.
+func (e *Engine) runStorageSizeGauge(ctx context.Context) {
+	if e.Store == nil || e.Store.Backend == nil {
+		return
+	}
+	ticker := time.NewTicker(storageSizeSampleInterval)
+	defer ticker.Stop()
+	e.recordTableBytes()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			e.recordTableBytes()
 		}
 	}
 }

--- a/internal/node/status.go
+++ b/internal/node/status.go
@@ -153,13 +153,13 @@ func (e *Engine) runStorageSizeGauge(ctx context.Context) {
 	}
 	ticker := time.NewTicker(storageSizeSampleInterval)
 	defer ticker.Stop()
-	e.recordTableBytes()
+	e.recordTableBytes(ctx)
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			e.recordTableBytes()
+			e.recordTableBytes(ctx)
 		}
 	}
 }

--- a/internal/node/storage_worker_shutdown_test.go
+++ b/internal/node/storage_worker_shutdown_test.go
@@ -1,0 +1,43 @@
+package node
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// Shutdown cancels the context, waits a fixed grace period, and then closes the
+// storage backend. Nothing joined the background samplers, so one still mid-round
+// when Close landed would call into a closed Pebble instance — which panics
+// rather than returning an error.
+//
+// WaitForStorageWorkers is what makes the ordering safe, so it has to actually
+// block until the sampler has returned.
+func TestWaitForStorageWorkersBlocksUntilSamplerReturns(t *testing.T) {
+	e := makeTestEngine()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	e.startWorkers(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		e.WaitForStorageWorkers()
+		close(done)
+	}()
+
+	// Nothing has been cancelled, so the sampler is still running and the wait
+	// must not have returned.
+	select {
+	case <-done:
+		t.Fatal("WaitForStorageWorkers returned while the sampler was still running")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitForStorageWorkers did not return after cancellation")
+	}
+}

--- a/internal/node/tick.go
+++ b/internal/node/tick.go
@@ -22,6 +22,7 @@ func (e *Engine) onTick() {
 		metrics.ObserveTickIntervalDuration(now.Sub(e.lastTick).Seconds())
 	}
 	e.lastTick = now
+	e.lastTickMs.Store(now.UnixMilli())
 
 	timestampMs := uint64(now.UnixMilli())
 
@@ -90,14 +91,27 @@ func (e *Engine) dispatchAggregationCycle(nowMs, currentSlot uint64, isAggregato
 	if currentSlot == e.aggregatedSlot {
 		return
 	}
-	// The sync-lag duty gate is spec-defined only for block and attestation; gean
-	// also applies it to aggregation. Aggregating on a stale view only produces
-	// best-effort aggregates that get dropped, so gating when lagging is safe and
-	// surfaces the not_synced skip reason.
-	if e.DutyGate != nil && !e.DutyGate.Decide("aggregation", currentSlot, e.Store.HeadSlot(), e.networkSeenSlot()) {
-		metrics.IncAggregatorSkipped(metrics.AggregatorSkipNotSynced)
-		return
-	}
+	// Aggregation is deliberately NOT behind the sync-lag duty gate, unlike block
+	// production and attestation.
+	//
+	// gean used to gate it, reasoning that aggregates built on a stale view get
+	// dropped anyway. That holds with several aggregators. It inverts with one:
+	// the sole aggregator withholds the aggregates the network is waiting on at
+	// exactly the moment it is furthest behind, so nothing justifies, nothing
+	// finalizes, finalization pruning never runs, and the lag that closed the
+	// gate gets worse. Observed on devnet-5 as not_synced climbing to ~4,100 per
+	// node with justification frozen; stopping two lagging nodes advanced
+	// justification 1,520 slots in five minutes.
+	//
+	// The spec agrees: leanSpec timeline.py gates interval 2 on `is_aggregator`
+	// alone. So does ethlambda, which has a duty gate and applies it to
+	// attestation and proposal but not to aggregation. lantern has no gate. Only
+	// ream gates aggregation.
+	//
+	// The work is bounded without the gate: a session has a slot-anchored
+	// deadline and MaxGroupsPerSession, so an aggregate built on a stale view
+	// costs one bounded proving budget and is dropped by peers — strictly better
+	// than not producing one at all.
 	if e.Store.AttestationSignatures.Len() == 0 && e.Store.NewPayloads.Len() == 0 {
 		metrics.IncAggregatorSkipped(metrics.AggregatorSkipOther)
 		return

--- a/internal/node/workers.go
+++ b/internal/node/workers.go
@@ -14,6 +14,8 @@ func (e *Engine) startWorkers(ctx context.Context) {
 	go e.runAttestationWorker(ctx)
 	go e.runAggregationWorker(ctx)
 	go e.runGossipMeshGauge(ctx)
+	go e.runStorageSizeGauge(ctx)
+	go e.runTickAgeGauge(ctx)
 }
 
 func (e *Engine) runAttestationWorker(ctx context.Context) {

--- a/internal/node/workers.go
+++ b/internal/node/workers.go
@@ -14,8 +14,15 @@ func (e *Engine) startWorkers(ctx context.Context) {
 	go e.runAttestationWorker(ctx)
 	go e.runAggregationWorker(ctx)
 	go e.runGossipMeshGauge(ctx)
-	go e.runStorageSizeGauge(ctx)
 	go e.runTickAgeGauge(ctx)
+
+	// The storage-size sampler reads the backend, so shutdown has to join it
+	// before Close: see Engine.WaitForStorageWorkers.
+	e.storageWorkers.Add(1)
+	go func() {
+		defer e.storageWorkers.Done()
+		e.runStorageSizeGauge(ctx)
+	}()
 }
 
 func (e *Engine) runAttestationWorker(ctx context.Context) {

--- a/internal/storage/interface.go
+++ b/internal/storage/interface.go
@@ -31,6 +31,12 @@ type Iterator interface {
 
 	Value() []byte
 
+	// Err reports why iteration stopped, or nil if it reached the end. Next
+	// returning false means "no more entries" *or* "iteration failed", and a
+	// caller that treats those the same silently accepts a partial scan as a
+	// complete one.
+	Err() error
+
 	Close()
 }
 

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -151,6 +151,10 @@ type sliceIterator struct {
 	pos     int
 }
 
+// Err always returns nil: the in-memory backend materialises its entries up
+// front, so iteration cannot fail part-way.
+func (it *sliceIterator) Err() error { return nil }
+
 func (it *sliceIterator) Next() bool {
 	it.pos++
 	return it.pos < len(it.entries)

--- a/internal/storage/pebble.go
+++ b/internal/storage/pebble.go
@@ -28,20 +28,26 @@ func (p *PebbleBackend) BeginWrite() (WriteBatch, error) {
 	return &pebbleWriteBatch{batch: p.db.NewBatch()}, nil
 }
 
+// EstimateTableBytes reports approximate on-disk (SST) bytes for a table.
+//
+// This asks Pebble's version metadata for the size of the table's key range
+// rather than reading the table. The previous implementation iterated every
+// entry and summed len(key)+len(value), which on the states and signed-block
+// tables meant gigabytes of decompressed reads per call — and it was called for
+// all six tables on every block import, on the dispatch goroutine.
+//
+// The number this returns is not the same number: it is compressed SST bytes
+// for the range, not logical live bytes, and it excludes anything still in the
+// memtable. For a size gauge that is the more useful figure anyway.
 func (p *PebbleBackend) EstimateTableBytes(table Table) uint64 {
-	rv, err := p.BeginRead()
-	if err != nil {
+	lower := tableKey(table, nil)
+	upper := prefixUpperBound(lower)
+	if upper == nil {
 		return 0
 	}
-	it, err := rv.PrefixIterator(table, nil)
+	total, err := p.db.EstimateDiskUsage(lower, upper)
 	if err != nil {
 		return 0
-	}
-	defer it.Close()
-
-	var total uint64
-	for it.Next() {
-		total += uint64(len(it.Key()) + len(it.Value()))
 	}
 	return total
 }

--- a/internal/storage/pebble.go
+++ b/internal/storage/pebble.go
@@ -191,6 +191,16 @@ func (it *pebbleIterator) Value() []byte {
 	return bytes.Clone(it.iter.Value())
 }
 
+// Err surfaces a mid-iteration failure. pebble.Iterator.Next returns false both
+// at the end of the range and on an I/O error, so without this a truncated scan
+// is indistinguishable from a complete one.
+func (it *pebbleIterator) Err() error {
+	if it.iter == nil {
+		return nil
+	}
+	return it.iter.Error()
+}
+
 func (it *pebbleIterator) Close() {
 	it.iter.Close()
 }

--- a/internal/storage/pebble_test.go
+++ b/internal/storage/pebble_test.go
@@ -320,9 +320,30 @@ func TestPebbleEstimateTableBytes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	size := b.EstimateTableBytes(TableMetadata)
-	if size != uint64(len("k")+len("value")) {
-		t.Fatalf("metadata size=%d, want %d", size, len("k")+len("value"))
+	// EstimateTableBytes reports SST bytes for the table's key range, so it sees
+	// nothing until the memtable is flushed. That is the documented contract:
+	// the gauge is coarse and sampled on a slow cadence, and the alternative —
+	// summing every key and value — is a full-table scan.
+	if size := b.EstimateTableBytes(TableMetadata); size != 0 {
+		t.Fatalf("unflushed metadata size=%d, want 0", size)
+	}
+
+	if err := b.db.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	metaSize := b.EstimateTableBytes(TableMetadata)
+	if metaSize == 0 {
+		t.Fatal("metadata size=0 after flush, want non-zero")
+	}
+
+	// Each table is estimated over its own prefix range, so a write to one must
+	// not be attributed to another. TableBlockHeaders was never written.
+	if size := b.EstimateTableBytes(TableBlockHeaders); size != 0 {
+		t.Fatalf("unwritten table size=%d, want 0", size)
+	}
+	if statesSize := b.EstimateTableBytes(TableStates); statesSize == 0 {
+		t.Fatal("states size=0 after flush, want non-zero")
 	}
 }
 

--- a/internal/store/blocks.go
+++ b/internal/store/blocks.go
@@ -202,22 +202,50 @@ func (s *ConsensusStore) HeadSlot() uint64 {
 // once, lazily, to seed it after a restart: a process that starts with an
 // existing database must not report slot 0 and read the whole network as stalled.
 func (s *ConsensusStore) MaxStoredBlockSlot() uint64 {
-	s.maxBlockSlotSeed.Do(func() {
-		s.ObserveStoredBlockSlot(s.scanMaxStoredBlockSlot())
-	})
+	if err := s.SeedMaxStoredBlockSlot(); err != nil {
+		logger.Error(logger.Store, "seed max stored block slot: %v", err)
+	}
 	return s.maxBlockSlot.Load()
 }
 
+// SeedMaxStoredBlockSlot recovers the high-water mark from disk. It is a no-op
+// once a scan has completed successfully.
+//
+// Call it during startup, before the dispatch loop runs: that removes the one
+// remaining full-table scan from the duty path, and it means a failure is
+// reported somewhere a person will see it rather than swallowed on a tick.
+// A failed attempt does not latch, so a later call retries.
+func (s *ConsensusStore) SeedMaxStoredBlockSlot() error {
+	if s == nil || s.maxBlockSlotSeeded.Load() {
+		return nil
+	}
+	s.maxBlockSlotSeedMu.Lock()
+	defer s.maxBlockSlotSeedMu.Unlock()
+	if s.maxBlockSlotSeeded.Load() {
+		return nil
+	}
+
+	max, err := s.scanMaxStoredBlockSlot()
+	if err != nil {
+		return err
+	}
+	s.ObserveStoredBlockSlot(max)
+	s.maxBlockSlotSeeded.Store(true)
+	return nil
+}
+
 // scanMaxStoredBlockSlot is the O(n) fallback, used only to seed the high-water
-// mark once per process.
-func (s *ConsensusStore) scanMaxStoredBlockSlot() uint64 {
+// mark. It reports an error rather than a partial answer: a truncated scan looks
+// exactly like an empty table, and caching that as the mark is worse than
+// retrying.
+func (s *ConsensusStore) scanMaxStoredBlockSlot() (uint64, error) {
 	rv, err := s.beginRead("max stored block slot")
 	if err != nil {
-		return 0
+		return 0, err
 	}
 	it, err := rv.PrefixIterator(storage.TableBlockHeaders, nil)
 	if err != nil {
-		return 0
+		return 0, fmt.Errorf("iterate block headers: %w", err)
 	}
 	defer it.Close()
 
@@ -232,7 +260,10 @@ func (s *ConsensusStore) scanMaxStoredBlockSlot() uint64 {
 			max = slot
 		}
 	}
-	return max
+	if err := it.Err(); err != nil {
+		return 0, fmt.Errorf("iterate block headers: %w", err)
+	}
+	return max, nil
 }
 
 func (s *ConsensusStore) InsertLiveChainEntry(slot uint64, root, parentRoot [32]byte) {

--- a/internal/store/blocks.go
+++ b/internal/store/blocks.go
@@ -25,6 +25,18 @@ func (s *ConsensusStore) GetBlockHeader(root [32]byte) *types.BlockHeader {
 	return h
 }
 
+// HasBlockHeader reports whether a block header is stored, without decoding it.
+// The proposal path asks this a handful of times per block; it used to answer
+// the same question by materialising every root in the table into a map.
+func (s *ConsensusStore) HasBlockHeader(root [32]byte) bool {
+	rv, err := s.beginRead("has block header")
+	if err != nil {
+		return false
+	}
+	val, err := rv.Get(storage.TableBlockHeaders, root[:])
+	return err == nil && val != nil
+}
+
 func (s *ConsensusStore) InsertBlockHeader(root [32]byte, header *types.BlockHeader) {
 	if err := s.PutBlockHeader(root, header); err != nil {
 		logger.Error(logger.Store, "%v", err)
@@ -39,7 +51,11 @@ func (s *ConsensusStore) PutBlockHeader(root [32]byte, header *types.BlockHeader
 	if err != nil {
 		return fmt.Errorf("insert block header: marshal: %w", err)
 	}
-	return s.putOne(storage.TableBlockHeaders, root[:], data, "insert block header")
+	if err := s.putOne(storage.TableBlockHeaders, root[:], data, "insert block header"); err != nil {
+		return err
+	}
+	s.ObserveStoredBlockSlot(header.Slot)
+	return nil
 }
 
 func (s *ConsensusStore) BlockRoots() (map[[32]byte]bool, error) {
@@ -174,7 +190,27 @@ func (s *ConsensusStore) HeadSlot() uint64 {
 	return h.Slot
 }
 
+// MaxStoredBlockSlot returns the highest slot of any stored block header.
+//
+// This is read on the tick loop by the duty gate, up to three times a slot. It
+// used to iterate TableBlockHeaders and decode every value, which is O(chain
+// length) and — because the header's first SSZ field is the slot — forced the
+// sstable value blocks to be read rather than just the keys. On a 22,600-block
+// chain that was one of several full-table scans starving the dispatch loop.
+//
+// The answer is now a high-water mark maintained on insert. The table is scanned
+// once, lazily, to seed it after a restart: a process that starts with an
+// existing database must not report slot 0 and read the whole network as stalled.
 func (s *ConsensusStore) MaxStoredBlockSlot() uint64 {
+	s.maxBlockSlotSeed.Do(func() {
+		s.ObserveStoredBlockSlot(s.scanMaxStoredBlockSlot())
+	})
+	return s.maxBlockSlot.Load()
+}
+
+// scanMaxStoredBlockSlot is the O(n) fallback, used only to seed the high-water
+// mark once per process.
+func (s *ConsensusStore) scanMaxStoredBlockSlot() uint64 {
 	rv, err := s.beginRead("max stored block slot")
 	if err != nil {
 		return 0

--- a/internal/store/consensus_store.go
+++ b/internal/store/consensus_store.go
@@ -1,6 +1,9 @@
 package store
 
 import (
+	"sync"
+	"sync/atomic"
+
 	"github.com/geanlabs/gean/internal/storage"
 	"github.com/geanlabs/gean/xmss"
 )
@@ -42,6 +45,42 @@ type ConsensusStore struct {
 	KnownPayloads         *PayloadBuffer
 	AttestationSignatures AttestationSignatureMap
 	PubKeyCache           *xmss.PubKeyCache
+
+	// maxBlockSlot is the highest slot of any block header this store has
+	// written: a high-water mark, not a live maximum over the table. It answers
+	// MaxStoredBlockSlot, which the duty gate reads up to three times a slot and
+	// which used to scan and SSZ-decode every header in TableBlockHeaders.
+	//
+	// It deliberately covers the same set the scan did — imported blocks and
+	// blocks stored while pending — because the duty gate's network-stall
+	// carve-out depends on it. Narrowing it to imported blocks only would let a
+	// node that restarted holding a pending block at a near-current slot read
+	// its own import lag as a network stall and resume duties on a stale head.
+	//
+	// The one behavioural difference from the scan: pruning the highest-slot
+	// header no longer lowers the answer. That errs toward reporting the network
+	// as alive, which is the direction that keeps the gate closed rather than
+	// opening it onto a dead fork.
+	maxBlockSlot     atomic.Uint64
+	maxBlockSlotSeed sync.Once
+}
+
+// ObserveStoredBlockSlot raises the stored-block high-water mark. Safe from any
+// goroutine: block import runs on the dispatch loop, but pending-block writes
+// and the test driver do not.
+func (s *ConsensusStore) ObserveStoredBlockSlot(slot uint64) {
+	if s == nil {
+		return
+	}
+	for {
+		current := s.maxBlockSlot.Load()
+		if slot <= current {
+			return
+		}
+		if s.maxBlockSlot.CompareAndSwap(current, slot) {
+			return
+		}
+	}
 }
 
 func NewConsensusStore(backend storage.Backend) *ConsensusStore {

--- a/internal/store/consensus_store.go
+++ b/internal/store/consensus_store.go
@@ -61,8 +61,16 @@ type ConsensusStore struct {
 	// header no longer lowers the answer. That errs toward reporting the network
 	// as alive, which is the direction that keeps the gate closed rather than
 	// opening it onto a dead fork.
-	maxBlockSlot     atomic.Uint64
-	maxBlockSlotSeed sync.Once
+	maxBlockSlot atomic.Uint64
+	// maxBlockSlotSeeded latches only once a seeding scan has completed without
+	// error. A sync.Once would latch on failure too, and a scan that returns 0
+	// because the read view could not be opened — or that stopped part-way
+	// through the table — would permanently understate the mark. That is not
+	// merely a bad gauge: an understated mark inflates the duty gate's computed
+	// network lag, which can trip the network-stall carve-out and let the node
+	// resume duties on a stale head.
+	maxBlockSlotSeeded atomic.Bool
+	maxBlockSlotSeedMu sync.Mutex
 }
 
 // ObserveStoredBlockSlot raises the stored-block high-water mark. Safe from any

--- a/internal/store/max_block_slot_test.go
+++ b/internal/store/max_block_slot_test.go
@@ -1,6 +1,7 @@
 package store_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/geanlabs/gean/internal/storage"
@@ -64,5 +65,64 @@ func TestMaxStoredBlockSlotSeedsFromDiskAfterRestart(t *testing.T) {
 	restarted.InsertBlockHeader([32]byte{3}, &types.BlockHeader{Slot: 111})
 	if got := restarted.MaxStoredBlockSlot(); got != 111 {
 		t.Fatalf("after post-seed insert = %d, want 111", got)
+	}
+}
+
+// failingIterBackend serves one read view whose iterator fails part-way through,
+// which is what a truncated scan looks like: Next reports false, exactly as it
+// does at the end of the table.
+type failingIterBackend struct{ storage.Backend }
+
+type truncatedIterator struct{ storage.Iterator }
+
+func (truncatedIterator) Next() bool  { return false }
+func (truncatedIterator) Err() error  { return errors.New("iteration failed") }
+func (truncatedIterator) Key() []byte { return nil }
+func (truncatedIterator) Close()      {}
+
+type failingIterView struct{ storage.ReadView }
+
+func (v failingIterView) PrefixIterator(table storage.Table, prefix []byte) (storage.Iterator, error) {
+	if table == storage.TableBlockHeaders {
+		return truncatedIterator{}, nil
+	}
+	return v.ReadView.PrefixIterator(table, prefix)
+}
+
+func (b failingIterBackend) BeginRead() (storage.ReadView, error) {
+	rv, err := b.Backend.BeginRead()
+	if err != nil {
+		return nil, err
+	}
+	return failingIterView{ReadView: rv}, nil
+}
+
+// A seeding scan that fails must not latch. Caching a partial answer is worse
+// than retrying: an understated mark inflates the duty gate's computed network
+// lag, which can trip the network-stall carve-out and let the node resume duties
+// on a stale head — the opposite of what the gate is for.
+func TestMaxStoredBlockSlotDoesNotLatchAFailedSeed(t *testing.T) {
+	inner := storage.NewInMemoryBackend()
+
+	seeded := store.NewConsensusStore(inner)
+	seeded.InsertBlockHeader([32]byte{1}, &types.BlockHeader{Slot: 109})
+
+	// Restart against a backend whose header scan is truncated.
+	broken := store.NewConsensusStore(failingIterBackend{Backend: inner})
+	if err := broken.SeedMaxStoredBlockSlot(); err == nil {
+		t.Fatal("truncated scan reported success")
+	}
+	if got := broken.MaxStoredBlockSlot(); got != 0 {
+		t.Fatalf("failed seed = %d, want 0", got)
+	}
+
+	// The failure must not have latched: a working store over the same data
+	// recovers the real mark.
+	recovered := store.NewConsensusStore(inner)
+	if err := recovered.SeedMaxStoredBlockSlot(); err != nil {
+		t.Fatalf("retry failed: %v", err)
+	}
+	if got := recovered.MaxStoredBlockSlot(); got != 109 {
+		t.Fatalf("after retry = %d, want 109", got)
 	}
 }

--- a/internal/store/max_block_slot_test.go
+++ b/internal/store/max_block_slot_test.go
@@ -68,61 +68,111 @@ func TestMaxStoredBlockSlotSeedsFromDiskAfterRestart(t *testing.T) {
 	}
 }
 
-// failingIterBackend serves one read view whose iterator fails part-way through,
-// which is what a truncated scan looks like: Next reports false, exactly as it
-// does at the end of the table.
-type failingIterBackend struct{ storage.Backend }
-
-type truncatedIterator struct{ storage.Iterator }
-
-func (truncatedIterator) Next() bool  { return false }
-func (truncatedIterator) Err() error  { return errors.New("iteration failed") }
-func (truncatedIterator) Key() []byte { return nil }
-func (truncatedIterator) Close()      {}
-
-type failingIterView struct{ storage.ReadView }
-
-func (v failingIterView) PrefixIterator(table storage.Table, prefix []byte) (storage.Iterator, error) {
-	if table == storage.TableBlockHeaders {
-		return truncatedIterator{}, nil
-	}
-	return v.ReadView.PrefixIterator(table, prefix)
+// failOncePartialBackend truncates the first block-header scan part-way through
+// and then behaves normally, so the same store can be seeded twice.
+//
+// The partial scan is the dangerous shape: it returns a plausible, lower slot
+// rather than an obvious zero, so a caller that mistakes "iteration stopped" for
+// "end of table" caches an understated watermark that looks entirely reasonable.
+type failOncePartialBackend struct {
+	storage.Backend
+	entriesBeforeFailure int
+	failed               bool
 }
 
-func (b failingIterBackend) BeginRead() (storage.ReadView, error) {
+func (b *failOncePartialBackend) BeginRead() (storage.ReadView, error) {
 	rv, err := b.Backend.BeginRead()
 	if err != nil {
 		return nil, err
 	}
-	return failingIterView{ReadView: rv}, nil
+	return &failOnceView{ReadView: rv, backend: b}, nil
 }
 
-// A seeding scan that fails must not latch. Caching a partial answer is worse
-// than retrying: an understated mark inflates the duty gate's computed network
-// lag, which can trip the network-stall carve-out and let the node resume duties
-// on a stale head — the opposite of what the gate is for.
-func TestMaxStoredBlockSlotDoesNotLatchAFailedSeed(t *testing.T) {
+type failOnceView struct {
+	storage.ReadView
+	backend *failOncePartialBackend
+}
+
+func (v *failOnceView) PrefixIterator(table storage.Table, prefix []byte) (storage.Iterator, error) {
+	it, err := v.ReadView.PrefixIterator(table, prefix)
+	if err != nil || table != storage.TableBlockHeaders || v.backend.failed {
+		return it, err
+	}
+	v.backend.failed = true
+	return &partialIterator{Iterator: it, remaining: v.backend.entriesBeforeFailure}, nil
+}
+
+// partialIterator yields a few real entries and then reports the failure the way
+// a storage backend does: Next goes false, exactly as at the end of the range,
+// with the reason available only from Err.
+type partialIterator struct {
+	storage.Iterator
+	remaining int
+}
+
+func (it *partialIterator) Next() bool {
+	if it.remaining <= 0 {
+		return false
+	}
+	it.remaining--
+	return it.Iterator.Next()
+}
+
+func (it *partialIterator) Err() error {
+	if it.remaining <= 0 {
+		return errors.New("iteration failed part-way")
+	}
+	return it.Iterator.Err()
+}
+
+// A seeding scan that fails must not latch, and the *same* store must recover on
+// a later attempt.
+//
+// Caching a partial answer is worse than retrying: an understated watermark
+// inflates the duty gate's computed network lag, which can trip the
+// network-stall carve-out and let the node resume duties on a stale head - the
+// opposite of what the gate is for.
+func TestMaxStoredBlockSlotRetriesAfterAFailedSeed(t *testing.T) {
 	inner := storage.NewInMemoryBackend()
 
-	seeded := store.NewConsensusStore(inner)
-	seeded.InsertBlockHeader([32]byte{1}, &types.BlockHeader{Slot: 109})
+	// Root order drives iteration order, so the truncated scan sees slot 5 and
+	// stops before slot 109. A latched failure would leave the mark at neither
+	// the truth nor an obvious zero.
+	seed := store.NewConsensusStore(inner)
+	seed.InsertBlockHeader([32]byte{0x01}, &types.BlockHeader{Slot: 5})
+	seed.InsertBlockHeader([32]byte{0x02}, &types.BlockHeader{Slot: 109})
 
-	// Restart against a backend whose header scan is truncated.
-	broken := store.NewConsensusStore(failingIterBackend{Backend: inner})
-	if err := broken.SeedMaxStoredBlockSlot(); err == nil {
+	backend := &failOncePartialBackend{Backend: inner, entriesBeforeFailure: 1}
+	s := store.NewConsensusStore(backend)
+
+	if err := s.SeedMaxStoredBlockSlot(); err == nil {
 		t.Fatal("truncated scan reported success")
 	}
-	if got := broken.MaxStoredBlockSlot(); got != 0 {
-		t.Fatalf("failed seed = %d, want 0", got)
-	}
-
-	// The failure must not have latched: a working store over the same data
-	// recovers the real mark.
-	recovered := store.NewConsensusStore(inner)
-	if err := recovered.SeedMaxStoredBlockSlot(); err != nil {
-		t.Fatalf("retry failed: %v", err)
-	}
-	if got := recovered.MaxStoredBlockSlot(); got != 109 {
+	if got := s.MaxStoredBlockSlot(); got != 109 {
+		// MaxStoredBlockSlot retries internally, so by now the second attempt
+		// has run and must have found the real maximum. A latched failure would
+		// return 0 or the partial 5.
 		t.Fatalf("after retry = %d, want 109", got)
+	}
+}
+
+// The same thing without going through MaxStoredBlockSlot, so the retry is
+// attributable to SeedMaxStoredBlockSlot itself rather than to a caller.
+func TestSeedMaxStoredBlockSlotIsRetryableOnTheSameStore(t *testing.T) {
+	inner := storage.NewInMemoryBackend()
+	seed := store.NewConsensusStore(inner)
+	seed.InsertBlockHeader([32]byte{0x01}, &types.BlockHeader{Slot: 5})
+	seed.InsertBlockHeader([32]byte{0x02}, &types.BlockHeader{Slot: 109})
+
+	s := store.NewConsensusStore(&failOncePartialBackend{Backend: inner, entriesBeforeFailure: 1})
+
+	if err := s.SeedMaxStoredBlockSlot(); err == nil {
+		t.Fatal("first seed reported success on a truncated scan")
+	}
+	if err := s.SeedMaxStoredBlockSlot(); err != nil {
+		t.Fatalf("second seed on the same store failed: %v", err)
+	}
+	if got := s.MaxStoredBlockSlot(); got != 109 {
+		t.Fatalf("after successful reseed = %d, want 109", got)
 	}
 }

--- a/internal/store/max_block_slot_test.go
+++ b/internal/store/max_block_slot_test.go
@@ -1,0 +1,68 @@
+package store_test
+
+import (
+	"testing"
+
+	"github.com/geanlabs/gean/internal/storage"
+	"github.com/geanlabs/gean/internal/store"
+	"github.com/geanlabs/gean/internal/types"
+)
+
+// MaxStoredBlockSlot feeds the duty gate's network-stall carve-out and is read
+// up to three times a slot on the dispatch loop, so it is a high-water mark
+// maintained on insert rather than a scan of every block header.
+func TestMaxStoredBlockSlotTracksInserts(t *testing.T) {
+	s := store.NewConsensusStore(storage.NewInMemoryBackend())
+
+	if got := s.MaxStoredBlockSlot(); got != 0 {
+		t.Fatalf("empty store = %d, want 0", got)
+	}
+
+	s.InsertBlockHeader([32]byte{1}, &types.BlockHeader{Slot: 7})
+	if got := s.MaxStoredBlockSlot(); got != 7 {
+		t.Fatalf("after insert at 7 = %d, want 7", got)
+	}
+
+	// A lower slot arriving later (backfill, a sibling branch) must not lower
+	// the mark — it reports the furthest the chain has been seen to reach.
+	s.InsertBlockHeader([32]byte{2}, &types.BlockHeader{Slot: 3})
+	if got := s.MaxStoredBlockSlot(); got != 7 {
+		t.Fatalf("after insert at 3 = %d, want 7", got)
+	}
+
+	s.InsertBlockHeader([32]byte{3}, &types.BlockHeader{Slot: 12})
+	if got := s.MaxStoredBlockSlot(); got != 12 {
+		t.Fatalf("after insert at 12 = %d, want 12", got)
+	}
+}
+
+// The mark lives in memory, so a process that restarts against an existing
+// database has to recover it before the duty gate reads it. Getting this wrong
+// is not a cosmetic bug: a fresh store reporting 0 makes the gate compute a
+// network lag of the entire chain length, take the network-stall branch, and
+// resume duties on a stale head — the dead-fork behaviour the carve-out exists
+// to prevent.
+//
+// The pending block matters specifically. It is written by storePendingBlock
+// and never imported, so it appears in TableBlockHeaders but not in the live
+// chain: an index built only from imported blocks would miss it and read slot
+// 100 here, ten slots behind the truth.
+func TestMaxStoredBlockSlotSeedsFromDiskAfterRestart(t *testing.T) {
+	backend := storage.NewInMemoryBackend()
+
+	first := store.NewConsensusStore(backend)
+	first.InsertBlockHeader([32]byte{1}, &types.BlockHeader{Slot: 100})
+	first.InsertBlockHeader([32]byte{2}, &types.BlockHeader{Slot: 109})
+
+	// Same database, new process.
+	restarted := store.NewConsensusStore(backend)
+	if got := restarted.MaxStoredBlockSlot(); got != 109 {
+		t.Fatalf("after restart = %d, want 109 (the persisted pending block)", got)
+	}
+
+	// Seeding happens once; inserts after it still raise the mark.
+	restarted.InsertBlockHeader([32]byte{3}, &types.BlockHeader{Slot: 111})
+	if got := restarted.MaxStoredBlockSlot(); got != 111 {
+		t.Fatalf("after post-seed insert = %d, want 111", got)
+	}
+}


### PR DESCRIPTION
## Description

The dispatch loop is a single goroutine and it keeps the slot clock. Four full-table Pebble scans were running on it, all O(chain length). At ~22,600 blocks the mean tick interval reached 38–288s against an 800ms target, and every duty the clock drives — propose, attest, aggregate, head update, prune — stopped. Silently: the code that would have reported a problem was never reached.

Four commits, each buildable on its own.

**`5bb11d1` — finalization pruning was inert (the root of the growth)**

`updateFinalizedFromHead` called `FC.Prune` *before* `PruneOnFinalization`. `FC.Prune` removes the finalized-below ancestors and every losing branch from the ProtoArray; `PruneOnFinalization` then asks that same array which roots to delete via `GetCanonicalAnalysis`. After the prune the parent walk terminates at the new root, so `canonical` has length 1 and `canonical[1:]` is empty, and the siblings are already gone so `nonCanonical` is empty. Both delete lists came back empty every time.

So `TableStates` and `TableBlockHeaders` were never pruned at all — only `pruneLiveChain` worked, because it scans by slot rather than going through fork choice. That is why devnet-5 held 13,184 states and ~22,600 headers after thousands of finalizations, and why the scans below got expensive enough to matter.

**`2c6c0da` — the scans**

| call site | before | after |
|---|---|---|
| `EstimateTableBytes` | iterated every entry of all six tables, copying keys and values, **per imported block** | Pebble range metadata, sampled off the loop |
| `StatesCount` | scanned 13,184 states **once per slot**, for one log line | removed |
| `MaxStoredBlockSlot` | scanned and SSZ-decoded every header, **up to 3×/slot** | `atomic.Uint64` high-water mark |
| `BlockRoots` | materialised every root into a map, **per proposal** | membership predicate |

`EstimateTableBytes` changes meaning: SST bytes for the key range, not logical live bytes, and it excludes the memtable. For a size gauge that is the more useful figure; the test asserts the new contract.

`MaxStoredBlockSlot` deliberately still covers **pending** headers, not just imported ones. A live-chain index would have been cheaper but would miss a persisted pending block — a node restarting with head 100 and a pending block at 109 would read its own import lag as a network stall and resume duties on a stale head, which is the dead-fork behaviour the gate's carve-out exists to prevent. Covered by `TestMaxStoredBlockSlotSeedsFromDiskAfterRestart`.

**`84e2ebf` — aggregation is no longer behind the sync-lag duty gate**

gean gated aggregation as well as block production and attestation, reasoning that aggregates built on a stale view get dropped anyway. That holds with several aggregators. It inverts with one: the sole aggregator withholds the aggregates the network is waiting on at exactly the moment it is furthest behind, so nothing justifies, nothing finalizes, pruning never runs, and the lag that closed the gate gets worse.

Observed on devnet-5 as `not_synced` climbing to ~4,100 per node with justification frozen; stopping two lagging nodes advanced justification 1,520 slots in five minutes.

Checked against the other implementations, on the branches they actually run:

| | attestation | proposal | aggregation |
|---|---|---|---|
| leanSpec `timeline.py:49` | — | — | **not gated** (`case 2 if is_aggregator`) |
| ethlambda (`build/leanvm-track-main`) | gated | gated | **not gated** |
| lantern | no gate | no gate | **not gated** |
| ream | gated | gated | gated |

ethlambda is the informative one: it *has* a duty gate and applies it to two of three duties. The exclusion is deliberate, not an omission.

Work stays bounded without the gate, but only *between* groups: a session has a slot-anchored deadline and `MaxGroupsPerSession`, and the deadline is checked between proofs. It cannot interrupt a native proof already running, so one overlong proof still overruns it. The bound is "at most `MaxGroupsPerSession` proofs per slot, the last of which may overrun" — not a hard time limit. Correcting an overstatement in the original description.

Drops the `not_synced` skip reason with it, since nothing can emit it now.

**`478f7e3` — signals that survive a stall**

`lean_tick_interval_duration_seconds` is observed *inside* `onTick`, so it records nothing while the loop is blocked: the failure it should report makes it go quiet rather than spike. Its top bucket is 1.6s besides, so it could not have sized a 288s stall. Adds `lean_tick_last_age_seconds` (written from outside the loop) and `lean_dispatch_event_duration_seconds{event}` with buckets to 600s, so a slow handler is attributable rather than only visible as a late tick.

### Evidence

30-second CPU profile of a stalled node:

```
49.12% cum   internal/storage.(*pebbleIterator).Next
26.89% flat  runtime/syscall.Syscall6
24.56% cum   os.(*File).pread
24.02% flat  github.com/golang/snappy.decode
```

The 24% in `snappy.decode` is the tell — only a scan that reads *values* decompresses that much, which is `recordTableBytes` and `StatesCount`. A goroutine dump put the dispatch goroutine inside `pebbleIterator.Next → sstable.readBlock → vfs.Prefetch → syscall`, not parked on a channel.

Degradation is monotonic in chain length:

| slot | tick interval | justified lag | finalized lag |
|---|---|---|---|
| ~600 | ~0.8s | −7 | −16 |
| ~15,400 | degraded | −77 | −126 |
| ~22,600 | 38–288s | frozen | frozen |

## Associated Issue

None — this targets `fix/aggregation-skip-visibility`, not `main` or a `devnet-N` branch.

Related context: #371 (recursive aggregation exceeding the slot budget, stalling finalization) describes the same symptom from a different cause; #368 (`ProtoArray.Prune()` O(N²)) is adjacent to the pruning path touched here but is not addressed.

### Review follow-ups (`8bfad59`)

Two lifecycle findings from review, both fixed:

- **A failed seeding scan latched permanently.** `scanMaxStoredBlockSlot` returned 0 for an unopenable read view, and a mid-iteration failure was indistinguishable from reaching the end of the table, since `Next` reports false either way. `sync.Once` then cached that understated mark forever. Not merely a bad gauge — an understated watermark inflates the duty gate's computed network lag, which can trip the network-stall carve-out and resume duties on a stale head, the behaviour the carve-out exists to prevent. `storage.Iterator` grows an `Err() error` so a truncated scan is distinguishable from a complete one; seeding reports errors, latches only on success, and now runs at startup before dispatch — which also removes the last full-table scan from the duty path.
- **The storage sampler could outlive shutdown.** `waitForShutdown` cancels, sleeps 500ms and returns; `backend.Close` then runs from a defer with nothing joining the workers. A sampler mid-round calls into a closed Pebble instance, which panics. Storage-reading goroutines are now tracked on a `WaitGroup` and joined in `main` before `Close`.

### Known gap, not addressed here

**Existing database bloat is not repaired.** Pruning only knows roots still in fork choice, and restart restoration anchors at the justified block (`internal/node/restore.go`), excluding older headers from replay. States orphaned by the pre-fix pruning bug therefore stay on disk indefinitely on an upgraded node. That wants a one-off cleanup, not another recurring scan on the dispatch path — worth its own issue. A node started from fresh data is unaffected.

## Test Plan

- `go test ./internal/...` — 25/25 packages pass; `go vet ./internal/...` and `gofmt` clean.
- Each of the four commits was checked out individually and built, so the branch is bisectable.
- **`TestFinalizationPrunesAncestorAndLosingBranch`** (new) — builds genesis → a(1) → b(2) → c(3) with a losing fork x(2), finalizes b, asserts x is removed entirely and a's state is dropped while b's and c's survive. Verified it *fails* on the pre-fix ordering with all three symptoms, which is the point of it.
- **`TestMaxStoredBlockSlotSeedsFromDiskAfterRestart`** (new) — head 100 with a persisted pending block at 109, new store over the same backend, asserts 109. This is the case a live-chain index would get wrong.
- **`TestMaxStoredBlockSlotTracksInserts`** (new) — the mark rises on insert and never falls.
- **`TestMaxStoredBlockSlotDoesNotLatchAFailedSeed`** (new) — a truncated header scan must report an error and must not cache its partial answer; a later store over the same data recovers the real mark.
- **`TestWaitForStorageWorkersBlocksUntilSamplerReturns`** (new) — the wait must not return while the sampler runs, and must return once the context is cancelled. Passes under `-race`.
- `TestPebbleEstimateTableBytes` updated to the new contract: zero before flush, non-zero after, each table attributed to its own prefix range.

### Devnet validation

Validated on a 15-node devnet — 4 gean, 6 ethlambda, 5 lantern, 4 committees, gean the sole aggregator. Fresh genesis, 14 hours, 12,400 slots, zero restarts.

**The tick loop never slipped.** `max_over_time` of the 10m mean tick interval across the whole run:

| node | worst over 14h | same node, old build |
|---|---|---|
| gean_0 | **0.8065 s** | 38.80 s |
| gean_1 | **0.8052 s** | 287.99 s |
| gean_2 | **0.8066 s** | 103.28 s |
| gean_3 | **0.8066 s** | 68.82 s |

Worst case in fourteen hours is 6.6 ms above an 800 ms target. Sampling gean_0 every 30 minutes across the run gives min 0.79998, max 0.80549, and the last sample (0.79999) is indistinguishable from the first (0.80000) — no drift, no rising tail. That matters more than the absolute number: the old build's failure mode was degradation *with chain length*, and 12,400 slots of growth produced no trend at all.

For reference, on the same network: lantern 0.7999–0.8001, ethlambda 0.8330–0.9261.

**Pruning is demonstrably running.** Before the ordering fix these counts were always zero:

```
04:11:01  pruning: finalized_slot=11604  states=94  blocks=23  live_chain=94  non_canonical=23
04:16:24  pruning: finalized_slot=11688  states=38  blocks=9   live_chain=38  non_canonical=9
04:41:33  pruning: finalized_slot=12057  states=82  blocks=26  live_chain=82  non_canonical=26
05:04:55  pruning: finalized_slot=12403  states=11  blocks=4   live_chain=11  non_canonical=4
```

`blocks` tracks `non_canonical` exactly, which is the losing-branch deletion the ordering bug prevented.

**The database is an order of magnitude smaller**, and smaller than ethlambda's at the same height (`lean_table_bytes`):

| table | gean_0 | ethlambda_0 |
|---|---|---|
| **states** | **16.2 MB** | 2.1 MB + 1.9 MB state_diffs |
| signed_blocks / block_proof | 1.243 GB | 1.703 GB |
| block_headers | 0.95 MB | 1.66 MB |
| live_chain | 0.97 MB | 1.11 MB |
| **total** | **~1.26 GB** | ~1.71 GB |

16 MB of states, against roughly 4.6 GB retained by the old build at a comparable height (13,184 states at ~350 KB). That retention is what made the scans fatal.

**Dispatch-event breakdown** (`lean_dispatch_event_duration_seconds`, new in this PR), gean_0 at slot 12,349:

| event | mean | share of an 800 ms interval |
|---|---|---|
| `tick` | 17 ms | 2% |
| `block` | 210 ms | 26% |
| `proposal_result` | 135 ms | 17% |
| `early_aggregate` | 2 ms | 0.3% |

`block` is the largest consumer and is the synchronous signature-verification and STF path noted below — comfortably inside budget for one block, but `drainPendingBlocks` can process up to 256 back-to-back.

**Two growth trends observed, neither blocking.** Between slot 166 and slot 12,349, `tick` went 6 ms → 17 ms and RSS went 2.3 GB → 3.8 GB. The first is expected: the database grew from empty to 1.26 GB, so point reads cost marginally more, and 17 ms of an 800 ms budget leaves no pressure. The second is **not** storage — a 16 MB states table cannot account for 3.8 GB of RSS, and ~97% of gean's RSS sits outside the Go heap in XMSS/leanVM allocations. That is a prover-memory question, separate from this PR, and worth its own issue.

### Behaviour changes worth knowing about

- `lean_aggregator_skipped_total{reason="not_synced"}` will stop appearing. Any dashboard panel keyed on it needs updating.
- gean will now aggregate while behind. Bounded, but expect `lean_aggregation_worker_total_time_seconds` to rise during catch-up.
- `EstimateTableBytes` reports a different quantity, so the storage-size gauge will step to new values on deploy.

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) (if applicable)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



