### PR TITLE
perf(store,attestation): stop decoding whole states to verify one signature

### DIFF
--- a/internal/attestation/verify.go
+++ b/internal/attestation/verify.go
@@ -13,13 +13,14 @@ func VerifyGossipAttestation(s *store.ConsensusStore, validatorID uint64, attDat
 		return err
 	}
 
-	targetState := s.GetState(attData.Target.Root)
-	if targetState == nil {
+	targetKeys := s.ValidatorKeys(attData.Target.Root)
+	if targetKeys == nil {
 		return fmt.Errorf("target state not found in store: 0x%x", attData.Target.Root)
 	}
-	if validatorID >= uint64(len(targetState.Validators)) {
+	pubkey, ok := targetKeys.AttestationPubkey(validatorID)
+	if !ok {
 		return fmt.Errorf("validator %d not found in state (registry size %d)",
-			validatorID, len(targetState.Validators))
+			validatorID, targetKeys.Len())
 	}
 	if len(signature) != types.SignatureSize {
 		return fmt.Errorf("signature length %d != expected %d", len(signature), types.SignatureSize)
@@ -27,7 +28,7 @@ func VerifyGossipAttestation(s *store.ConsensusStore, validatorID uint64, attDat
 	var sig [types.SignatureSize]byte
 	copy(sig[:], signature)
 	valid, err := xmss.VerifySignatureSSZ(
-		targetState.Validators[validatorID].AttestationPubkey,
+		pubkey,
 		uint32(attData.Slot),
 		dataRoot,
 		sig,
@@ -46,27 +47,27 @@ func VerifyAggregatedGossipAttestation(s *store.ConsensusStore, attData *types.A
 		return err
 	}
 
-	targetState := s.GetState(attData.Target.Root)
-	if targetState == nil {
+	targetKeys := s.ValidatorKeys(attData.Target.Root)
+	if targetKeys == nil {
 		return fmt.Errorf("target state not found in store: 0x%x", attData.Target.Root)
 	}
 	participantIDs := types.BitlistIndices(participants)
-	return verifyAggregatedProof(targetState, participantIDs, attData, proofData)
+	return verifyAggregatedProof(targetKeys, participantIDs, attData, proofData)
 }
 
 func verifyAggregatedProof(
-	state *types.State,
+	keys *store.ValidatorKeys,
 	participantIDs []uint64,
 	data *types.AttestationData,
 	proofData []byte,
 ) error {
-	numValidators := uint64(len(state.Validators))
 	parsedPubkeys := make([]xmss.CPubKey, len(participantIDs))
 	for i, vid := range participantIDs {
-		if vid >= numValidators {
-			return fmt.Errorf("validator %d out of range (%d)", vid, numValidators)
+		pubkey, ok := keys.AttestationPubkey(vid)
+		if !ok {
+			return fmt.Errorf("validator %d out of range (%d)", vid, keys.Len())
 		}
-		pk, err := xmss.ParsePublicKey(state.Validators[vid].AttestationPubkey)
+		pk, err := xmss.ParsePublicKey(pubkey)
 		if err != nil {
 			for j := range i {
 				xmss.FreePublicKey(parsedPubkeys[j])

--- a/internal/store/consensus_store.go
+++ b/internal/store/consensus_store.go
@@ -71,6 +71,14 @@ type ConsensusStore struct {
 	// resume duties on a stale head.
 	maxBlockSlotSeeded atomic.Bool
 	maxBlockSlotSeedMu sync.Mutex
+
+	// validatorKeys caches each state's attestation public keys by state root so
+	// signature verification does not decode a whole state to read one key. See
+	// ValidatorKeys. validatorKeysOrder records insertion order and is the
+	// eviction queue; both are guarded by validatorKeysMu.
+	validatorKeysMu    sync.Mutex
+	validatorKeys      map[[32]byte]*ValidatorKeys
+	validatorKeysOrder [][32]byte
 }
 
 // ObserveStoredBlockSlot raises the stored-block high-water mark. Safe from any

--- a/internal/store/consensus_store.go
+++ b/internal/store/consensus_store.go
@@ -106,5 +106,6 @@ func NewConsensusStore(backend storage.Backend) *ConsensusStore {
 		KnownPayloads:         NewPayloadBuffer(aggregatedPayloadCap),
 		AttestationSignatures: NewAttestationSignatureMap(gossipSignatureCap),
 		PubKeyCache:           xmss.NewPubKeyCache(),
+		validatorKeys:         make(map[[32]byte]*ValidatorKeys, validatorKeysCacheSize),
 	}
 }

--- a/internal/store/counting_backend_test.go
+++ b/internal/store/counting_backend_test.go
@@ -1,0 +1,35 @@
+package store_test
+
+import (
+	"sync/atomic"
+
+	"github.com/geanlabs/gean/internal/storage"
+)
+
+// countingBackend counts the Get calls that reach the backend, so a test can
+// assert that a cache actually spared the read rather than merely returning the
+// right answer.
+type countingBackend struct {
+	storage.Backend
+	gets atomic.Int64
+}
+
+func (b *countingBackend) reads() int64 { return b.gets.Load() }
+
+func (b *countingBackend) BeginRead() (storage.ReadView, error) {
+	rv, err := b.Backend.BeginRead()
+	if err != nil {
+		return nil, err
+	}
+	return &countingReadView{ReadView: rv, owner: b}, nil
+}
+
+type countingReadView struct {
+	storage.ReadView
+	owner *countingBackend
+}
+
+func (v *countingReadView) Get(table storage.Table, key []byte) ([]byte, error) {
+	v.owner.gets.Add(1)
+	return v.ReadView.Get(table, key)
+}

--- a/internal/store/validator_keys.go
+++ b/internal/store/validator_keys.go
@@ -90,9 +90,6 @@ func (s *ConsensusStore) ValidatorKeys(root [32]byte) *ValidatorKeys {
 	if existing, ok := s.validatorKeys[root]; ok {
 		return existing
 	}
-	if s.validatorKeys == nil {
-		s.validatorKeys = make(map[[32]byte]*ValidatorKeys, validatorKeysCacheSize)
-	}
 	if len(s.validatorKeysOrder) >= validatorKeysCacheSize {
 		delete(s.validatorKeys, s.validatorKeysOrder[0])
 		s.validatorKeysOrder = s.validatorKeysOrder[1:]

--- a/internal/store/validator_keys.go
+++ b/internal/store/validator_keys.go
@@ -1,0 +1,103 @@
+package store
+
+import (
+	"github.com/geanlabs/gean/internal/types"
+)
+
+// validatorKeysCacheSize bounds the cache. An attestation's target is the safe
+// target checkpoint, which advances at most once per slot and often stands for
+// several: a devnet node produced 53 attestations across 6 distinct target
+// roots. Sixty-four leaves room for reorgs and for the spread of targets the
+// rest of the network votes for without the cache ever becoming a memory item
+// of its own — each entry is one 32-byte key per validator.
+const validatorKeysCacheSize = 64
+
+// ValidatorKeys is an immutable snapshot of one state's attestation public
+// keys, in validator-index order.
+//
+// Accessors hand back arrays by value rather than exposing the slice, so a
+// cached snapshot cannot be aliased and mutated by a caller. That is the whole
+// reason this type exists instead of a cache in front of GetState: GetState
+// returns a fresh state on every call because callers such as the block
+// processor pass the result straight into StateTransition, which mutates it.
+// Caching what GetState returns would let one of those callers corrupt the
+// state that signature verification reads.
+type ValidatorKeys struct {
+	keys [][types.PubkeySize]byte
+}
+
+// Len reports the size of the validator registry.
+func (v *ValidatorKeys) Len() int {
+	if v == nil {
+		return 0
+	}
+	return len(v.keys)
+}
+
+// AttestationPubkey returns the attestation public key of the validator at
+// index, and whether that index is in the registry.
+func (v *ValidatorKeys) AttestationPubkey(index uint64) ([types.PubkeySize]byte, bool) {
+	if v == nil || index >= uint64(len(v.keys)) {
+		return [types.PubkeySize]byte{}, false
+	}
+	return v.keys[index], true
+}
+
+// ValidatorKeys returns the attestation public keys of the validator registry
+// at root, or nil when no state is stored for that root.
+//
+// Signature verification needs one 32-byte key, but reaching it through
+// GetState decodes the entire state to get there. A state is dominated by
+// HistoricalBlockHashes, which holds one 32-byte entry per slot since genesis:
+// about 628 KB at slot 20,000, decoded in 2.1 ms across 20,023 allocations,
+// and growing for as long as the chain does. Verification never reads any of
+// it. Gossip verification runs a few times a second on every node, so that was
+// megabytes a second of garbage produced to reach a few hundred bytes.
+//
+// Caching by state root is sound because a root determines its state: an entry
+// can go stale only by outliving the state it describes, which costs nothing
+// beyond the bounded space it sits in.
+func (s *ConsensusStore) ValidatorKeys(root [32]byte) *ValidatorKeys {
+	if s == nil {
+		return nil
+	}
+
+	s.validatorKeysMu.Lock()
+	cached, ok := s.validatorKeys[root]
+	s.validatorKeysMu.Unlock()
+	if ok {
+		return cached
+	}
+
+	// Built outside the lock: this is the expensive path, and holding the mutex
+	// across it would serialise every verifier behind one decode.
+	state := s.GetState(root)
+	if state == nil {
+		return nil
+	}
+	vk := &ValidatorKeys{keys: make([][types.PubkeySize]byte, len(state.Validators))}
+	for i, validator := range state.Validators {
+		if validator == nil {
+			continue
+		}
+		vk.keys[i] = validator.AttestationPubkey
+	}
+
+	s.validatorKeysMu.Lock()
+	defer s.validatorKeysMu.Unlock()
+	// Two verifiers can miss on the same root concurrently. Keep whichever
+	// landed first so every caller observes one snapshot per root.
+	if existing, ok := s.validatorKeys[root]; ok {
+		return existing
+	}
+	if s.validatorKeys == nil {
+		s.validatorKeys = make(map[[32]byte]*ValidatorKeys, validatorKeysCacheSize)
+	}
+	if len(s.validatorKeysOrder) >= validatorKeysCacheSize {
+		delete(s.validatorKeys, s.validatorKeysOrder[0])
+		s.validatorKeysOrder = s.validatorKeysOrder[1:]
+	}
+	s.validatorKeys[root] = vk
+	s.validatorKeysOrder = append(s.validatorKeysOrder, root)
+	return vk
+}

--- a/internal/store/validator_keys_test.go
+++ b/internal/store/validator_keys_test.go
@@ -1,0 +1,138 @@
+package store_test
+
+import (
+	"testing"
+
+	"github.com/geanlabs/gean/internal/storage"
+	"github.com/geanlabs/gean/internal/store"
+	"github.com/geanlabs/gean/internal/types"
+)
+
+// stateWithValidators builds a state whose registry is identifiable by index
+// and whose HistoricalBlockHashes is long enough to stand in for a real one.
+func stateWithValidators(t *testing.T, count int, history int) *types.State {
+	t.Helper()
+	st := &types.State{
+		Config:            &types.ChainConfig{},
+		Slot:              uint64(history),
+		LatestBlockHeader: &types.BlockHeader{},
+		LatestJustified:   &types.Checkpoint{},
+		LatestFinalized:   &types.Checkpoint{},
+	}
+	st.HistoricalBlockHashes = make([][]byte, history)
+	for i := range history {
+		b := make([]byte, types.RootSize)
+		b[0] = byte(i)
+		st.HistoricalBlockHashes[i] = b
+	}
+	st.JustifiedSlots = make([]byte, history/8+1)
+	st.JustifiedSlots[history/8] |= 1 << (history % 8)
+	st.Validators = make([]*types.Validator, count)
+	for i := range count {
+		v := &types.Validator{Index: uint64(i)}
+		v.AttestationPubkey[0] = byte(i + 1)
+		st.Validators[i] = v
+	}
+	st.JustificationsValidators = []byte{0x01}
+	return st
+}
+
+func TestValidatorKeysReadsRegistry(t *testing.T) {
+	s := store.NewConsensusStore(storage.NewInMemoryBackend())
+	root := [32]byte{9}
+	s.InsertState(root, stateWithValidators(t, 4, 32))
+
+	keys := s.ValidatorKeys(root)
+	if keys == nil {
+		t.Fatal("ValidatorKeys returned nil for a stored state")
+	}
+	if got := keys.Len(); got != 4 {
+		t.Fatalf("registry size = %d, want 4", got)
+	}
+	for i := range 4 {
+		pubkey, ok := keys.AttestationPubkey(uint64(i))
+		if !ok {
+			t.Fatalf("validator %d reported out of range", i)
+		}
+		if pubkey[0] != byte(i+1) {
+			t.Fatalf("validator %d key[0] = %d, want %d", i, pubkey[0], i+1)
+		}
+	}
+
+	// Out-of-range must be reported, not panic: participant indices arrive from
+	// gossip and are attacker-influenced.
+	if _, ok := keys.AttestationPubkey(4); ok {
+		t.Fatal("index past the registry reported in range")
+	}
+}
+
+// An unknown root is how verification learns the target state is missing, so it
+// has to stay distinguishable from an empty registry.
+func TestValidatorKeysUnknownRootIsNil(t *testing.T) {
+	s := store.NewConsensusStore(storage.NewInMemoryBackend())
+	if keys := s.ValidatorKeys([32]byte{7}); keys != nil {
+		t.Fatalf("unknown root returned %v, want nil", keys)
+	}
+}
+
+// The point of the cache is that verification stops decoding a whole state per
+// attestation, so a repeat call must not touch the backend again. Without the
+// cache this reads the state — 628 KB and 20,023 allocations at slot 20,000 —
+// several times a second on every node.
+func TestValidatorKeysCachesByRoot(t *testing.T) {
+	backend := &countingBackend{Backend: storage.NewInMemoryBackend()}
+	s := store.NewConsensusStore(backend)
+	root := [32]byte{3}
+	s.InsertState(root, stateWithValidators(t, 3, 64))
+
+	if keys := s.ValidatorKeys(root); keys == nil {
+		t.Fatal("first call returned nil")
+	}
+	afterFirst := backend.reads()
+	if afterFirst == 0 {
+		t.Fatal("first call did not read the backend")
+	}
+
+	for range 20 {
+		if keys := s.ValidatorKeys(root); keys == nil || keys.Len() != 3 {
+			t.Fatal("cached call returned the wrong snapshot")
+		}
+	}
+	if got := backend.reads(); got != afterFirst {
+		t.Fatalf("cached calls read the backend %d extra times, want 0", got-afterFirst)
+	}
+}
+
+// The hazard this type exists to avoid. GetState hands out a fresh state on
+// every call because callers such as the block processor pass the result
+// straight into StateTransition, which appends to HistoricalBlockHashes and
+// rewrites the registry. Had the cache sat in front of GetState, one of those
+// callers would be mutating the snapshot verification reads.
+func TestValidatorKeysUnaffectedByStateMutation(t *testing.T) {
+	s := store.NewConsensusStore(storage.NewInMemoryBackend())
+	root := [32]byte{5}
+	s.InsertState(root, stateWithValidators(t, 2, 16))
+
+	// A caller in the block-processing shape: take the state, mutate it.
+	mutable := s.GetState(root)
+	if mutable == nil {
+		t.Fatal("GetState returned nil")
+	}
+	mutable.Validators[0].AttestationPubkey[0] = 0xff
+	mutable.Validators = mutable.Validators[:1]
+
+	keys := s.ValidatorKeys(root)
+	if keys == nil {
+		t.Fatal("ValidatorKeys returned nil")
+	}
+	if got := keys.Len(); got != 2 {
+		t.Fatalf("registry size = %d after a caller truncated its own copy, want 2", got)
+	}
+	pubkey, ok := keys.AttestationPubkey(0)
+	if !ok {
+		t.Fatal("validator 0 reported out of range")
+	}
+	if pubkey[0] != 1 {
+		t.Fatalf("validator 0 key[0] = %d, want 1: a caller's mutation reached the snapshot", pubkey[0])
+	}
+}


### PR DESCRIPTION
Gossip signature verification needs one 32-byte attestation public key, and was reaching it by decoding the entire state. A state is dominated by `HistoricalBlockHashes`, one 32-byte entry per slot since genesis, which verification never reads.

| state at slot | size | decode | allocations |
|---|---|---|---|
| 1,000 | 32 KB | 0.16 ms | 1,023 |
| 10,000 | 315 KB | 0.60 ms | 10,023 |
| 20,000 | **628 KB** | **2.09 ms** | **20,023** (1.13 MB) |

Linear in slot number, so it degrades for as long as the chain runs.

`ValidatorKeys` caches the validator registry by state root and hands keys back as arrays by value.

**The cache deliberately does not sit in front of `GetState`.** `GetState` returns a fresh state on every call because callers depend on it: `blockprocessor/process.go:40` passes `parentState` straight into `StateTransition`, which appends to `HistoricalBlockHashes` (`statetransition/block.go:88`); `proposal.go:185` and `recovery.go:98` have the same shape. Caching there would hand a mutating caller the object verification reads. `TestValidatorKeysUnaffectedByStateMutation` pins that.

Caching by root is sound because a root determines its state. Sixty-four entries covers the working set: a devnet node produced 53 attestations across **6 distinct target roots**, since the target is the safe-target checkpoint and advances at most once a slot.

## Devnet validation

Measured on a 15-node devnet against the previous build, **compared at matched slot** (new run at 12,070 vs old at 12,131) so the comparison is like-for-like — the effect grows with chain length, and an early sample would show nothing.

**Single-attestation verification:**

| node | before | after | |
|---|---|---|---|
| gean_0 | 5.24 ms | **2.09 ms** | −60% |
| gean_2 | 5.56 ms | **1.49 ms** | −73% |
| gean_3 | 5.05 ms | **1.58 ms** | −69% |
| *ethlambda_0 (control)* | 0.732 ms | 0.727 ms | flat |
| *ethlambda_1 (control)* | 0.787 ms | 0.751 ms | flat |

Controls flat, workload matched (9.6 vs 9.1 attestations per aggregate, 2.59 vs 2.54 verifications/s). Allocation rate fell 11.39 → 8.33 MB/s.

The prediction was that the old build's cost climbs with chain length while the fixed build stays flat. The old build measured 1.37 ms at slot 1,118 rising to 10.24 ms at slot 20,018; the fixed build sits at 1.5–2.1 ms. Slope of the unfixed curve was 0.47 µs/slot against 0.1 µs/slot from the decoder benchmark scaled for a loaded host.

Tick interval 0.800 s throughout, zero restarts across four nodes over 13 hours.

## What this does not address

Aggregated-proof verification, where gean measured ~0.22 s against ethlambda's ~0.09 s. A later role-swap experiment showed roughly two thirds of that gap is self-contention — gean competing with its own proving — and it disappears when gean stops aggregating. The remaining ~1.6x is unexplained: same leanVM revision, same build profile, equivalent target CPU, identical proof sizes. It needs profiling, not another metrics pass, and it is unaffected by this change.

## Scope note

An earlier revision of this PR also set `MALLOC_ARENA_MAX=2` in the Dockerfile for #424. That has been removed. It worked, but devnet testing since showed `LD_PRELOAD` with jemalloc achieves the same result while *returning* memory rather than capping retention, and the arena cap was implicated in amplifying #430 — a thread wedged while holding one of only two arenas took a whole node down. The allocator change will come separately with its own validation.

## Testing

`make test` green across all 25 packages, `gofmt` and `go vet` clean. Four new tests in `internal/store`; `TestValidatorKeysCachesByRoot` was confirmed to fail on the unfixed path (20 extra backend reads) rather than passing vacuously.

Closes #426
