### PR TITLE
chore(comments): drop other-client names from five comments

### DIFF
--- a/internal/aggregation/aggregate.go
+++ b/internal/aggregation/aggregate.go
@@ -159,7 +159,7 @@ const seedPerGroupSeconds = 0.3
 // aggregators covering four subnets saturated a 16-core host and left the node
 // 129 slots behind. A count is a cruder bound than the wall-clock deadline, but
 // it is the one that holds before any proof has started, so the gate token is
-// never held for an unbounded stretch. ethlambda uses the same value.
+// never held for an unbounded stretch.
 const MaxGroupsPerSession = 2
 
 // MaxGroupsWhenProposing applies in the slot before this node proposes. The

--- a/internal/aggregation/proofs.go
+++ b/internal/aggregation/proofs.go
@@ -13,8 +13,7 @@ import (
 // A child is a recursive input: measured on a 16-core host, a group carrying one
 // costs 1.68-2.96s against 0.31-0.91s for raw signatures alone, with no overlap
 // between the ranges. The cap bounds the worst case a single group can spend
-// once raw-first selection has already removed most recursion. ethlambda and
-// lantern both settled on the same value.
+// once raw-first selection has already removed most recursion.
 const maxChildProofsPerGroup = 2
 
 // selectChildProofs folds coverage-adding child proofs into the aggregation

--- a/internal/node/tick.go
+++ b/internal/node/tick.go
@@ -104,9 +104,8 @@ func (e *Engine) dispatchAggregationCycle(nowMs, currentSlot uint64, isAggregato
 	// justification 1,520 slots in five minutes.
 	//
 	// The spec agrees: leanSpec timeline.py gates interval 2 on `is_aggregator`
-	// alone. So does ethlambda, which has a duty gate and applies it to
-	// attestation and proposal but not to aggregation. lantern has no gate. Only
-	// ream gates aggregation.
+	// alone. Gating it on anything else is gean's own addition, and the paragraph
+	// above is why it has to go.
 	//
 	// The work is bounded without the gate: a session has a slot-anchored
 	// deadline and MaxGroupsPerSession, so an aggregate built on a stale view

--- a/internal/store/gossip.go
+++ b/internal/store/gossip.go
@@ -169,11 +169,11 @@ func entryTargetSlot(entry *AttestationDataEntry) uint64 {
 // slot does not move, so a finalization-keyed prune never fires and the pool
 // grows for as long as the stall lasts.
 //
-// ream and grandine exempt roots that carry an aggregated payload from their
-// equivalent sweeps, to keep the coverage a live aggregate was built from. That
-// exemption cannot apply here: a root's signature entry and its payload entry
-// hold the same AttestationData, so they share a target slot and go stale in the
-// same sweep. Nothing would ever be exempt.
+// An equivalent sweep might exempt roots that carry an aggregated payload, to
+// keep the coverage a live aggregate was built from. That exemption cannot apply
+// here: a root's signature entry and its payload entry hold the same
+// AttestationData, so they share a target slot and go stale in the same sweep.
+// Nothing would ever be exempt.
 func (m *AttestationSignatureMap) PruneStaleBelow(cutoff uint64) int {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/store/prune_test.go
+++ b/internal/store/prune_test.go
@@ -63,7 +63,7 @@ func TestPruneStaleAttestationPools(t *testing.T) {
 		// Signature entry and payload entry share one AttestationData, so they
 		// share a target slot and go stale together. Neither can outlive the
 		// other, which is why the sweep needs no exemption for payload-bearing
-		// roots the way ream's and grandine's do.
+		// roots.
 		if _, ok := s.AttestationSignatures.Snapshot()[stale]; ok {
 			t.Fatal("stale signatures survived")
 		}


### PR DESCRIPTION
Closes #429.

Five committed comments justified a value or a decision by naming what another client does. Comments in this tree stay peculiar to gean, so the names go — but every measurement and every piece of reasoning stays.

| file | named | what remains |
|---|---|---|
| `internal/node/tick.go` | ethlambda, lantern, ream | the leanSpec cross-reference, which is the actual justification |
| `internal/store/gossip.go` | ream, grandine | gean's own reasoning about why nothing could be exempt |
| `internal/store/prune_test.go` | ream, grandine | same, mirrors the implementation comment |
| `internal/aggregation/proofs.go` | ethlambda, lantern | the 1.68–2.96s vs 0.31–0.91s measurement |
| `internal/aggregation/aggregate.go` | ethlambda | the four-aggregators / 129-slots-behind measurement |

The only one needing judgement was `tick.go`, which also carries the leanSpec reference — `timeline.py` gates interval 2 on `is_aggregator` alone. A short spec cross-reference is explicitly allowed and is the real justification for removing gean's gate; the survey of what other clients do was not. The devnet evidence in the paragraph above it is untouched.

## Verification

**Comment-only.** Checked mechanically, not by eye — every changed line in the diff is a comment or blank:

```
git diff -U0 | grep -E "^[+-]" | grep -v "^(\+\+\+|---)" | grep -vE "^[+-][[:space:]]*(//|$)"
→ no output
```

No code line is touched. `internal/node/tick.go` and `internal/store/gossip.go` are consensus-critical paths, which is why that check matters here.

**Suite:** `make test` exits 0 with zero failures across all 25 packages. `gofmt` and `go vet` clean.

**No names left anywhere:**

```
git grep -iE "ethlambda|zeam|lantern|grandine|\bream\b|nimbus|lighthouse|prysm|teku" -- '*.go' Dockerfile Makefile
→ no matches
```

5 files changed, 10 insertions(+), 12 deletions(-).
