### PR TITLE
perf(docker): prove on jemalloc instead of glibc malloc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,20 @@ RUN CHECKOUT_ROOT=$(cat /tmp/leanvm-staged/.checkout_root) && \
     rm -rf /tmp/leanvm-staged
 
 
+# Prove on jemalloc, not glibc malloc. The prover frees its scratch after every
+# proof, but glibc keeps it: most lands in the main heap, which only shrinks from
+# the top, so one live allocation pins everything below it. jemalloc uses mmap and
+# returns pages on a decay timer. Devnet, same slot: 448 MB against 1,126-1,150 MB
+# on glibc nodes. See #424.
+#
+# Unqualified soname so ld.so resolves it per architecture (this image builds
+# arm64 too). The ldconfig check fails the build rather than letting a missing
+# library become a silent runtime warning.
+RUN apt-get update && apt-get install -y --no-install-recommends libjemalloc2 \
+    && rm -rf /var/lib/apt/lists/* \
+    && ldconfig -p | grep -q 'libjemalloc\.so\.2'
+ENV LD_PRELOAD=libjemalloc.so.2
+
 # Keep the Go heap tight so the XMSS prover's transient multi-GB proving
 # peaks (allocated by the Rust arena, invisible to the Go GC) land on free
 # memory instead of an uncollected heap. Operators can override.


### PR DESCRIPTION
One Dockerfile change: install `libjemalloc2` and `LD_PRELOAD` it, so the prover's allocations go through jemalloc rather than glibc malloc.

Refs #424, and supersedes the `MALLOC_ARENA_MAX=2` approach that was withdrawn from #427 before merge.

## Why

The prover allocates its scratch through the system allocator and frees it after each proof. glibc takes it back but does not hand it to the OS. Most of it lands in the **main heap**, which can only shrink from the top — one live allocation above a freed block pins everything below it for the life of the process. jemalloc allocates only via `mmap` and releases pages on a decay timer.

## Measurement

One node on jemalloc, three on glibc. Same image, same chain, same slot, same host — the allocator is the only difference.

| node | allocator | RSS at slot 3,440 | brk heap |
|---|---|---|---|
| **gean_0** | **jemalloc** | **448 MB** | **0** |
| gean_1 | glibc | 1,150 MB | 264 |
| gean_2 | glibc | 1,135 MB | 302 |
| gean_3 | glibc | 1,126 MB | 694 |

**60% reduction, sustained ~1,900 slots** after the swap — not an early-run artifact.

The *shape* is the stronger evidence. The jemalloc node oscillates as memory is taken and returned; the glibc nodes are pinned flat because theirs cannot come back:

```
gean_0 (jemalloc)  351 → 410 → 357 → 455 → 543 → 454 → 472 → 715 → 532 → 435 → 448 MB
gean_1 (glibc)     973 → 1000 → 973 → 1008 → 1011 → 1030 → 1018 → 975 → … → 1150 MB
```

gean_0's **peak (715 MB) stays below every control's floor (973 MB)**.

## No measured cost

| node | signing rate/s | agg verify | CPU cores | tick |
|---|---|---|---|---|
| **gean_0 (jemalloc)** | **0.204** | **132.7 ms** | **0.605** | 0.800 s |
| gean_1 | 0.193 | 135.4 ms | 0.666 | 0.800 s |
| gean_2 | 0.196 | 140.2 ms | 0.977 | 0.800 s |
| gean_3 | 0.193 | 158.5 ms | 0.892 | 0.800 s |

Highest signing rate, fastest aggregated-signature verification, lowest CPU, identical tick. Same justified and finalized slots as the other three, in sync, zero restarts.

## Why not `MALLOC_ARENA_MAX=2`

It worked (~69% on its own measurement) but:

- it bounds *retention* and cannot return what the main heap already holds — `brk` was still 264–694 MB on the capped nodes
- it costs allocator concurrency, and that cost grows with the validator set
- it is implicated in #430: a thread wedged in `vm_mmap_pgoff` while holding one of only **two** arenas took a whole node down ~2.5 hours later, unkillable, requiring a host reboot

jemalloc addresses the class of problem instead of capping a symptom.

## Notes on the change

**Unqualified soname is deliberate.** `ld.so` resolves `libjemalloc.so.2` per architecture, and this image builds for arm64 too; a hardcoded `x86_64` path would silently degrade there. Verified that `ldconfig -p` resolves the bare soname, and that `libjemalloc2` is the providing package.

**The `ldconfig` check fails the build** rather than letting a missing library become a runtime warning that's easy to miss — a silent failure here would look exactly like "jemalloc didn't help".

## Validation status — please read

The **mechanism** is validated on devnet, but via `LD_PRELOAD` with the host's library bind-mounted into the running container, not via this Dockerfile. The library and the mechanism are identical; what has **not** been exercised end-to-end is the image build path.

So on the first devnet run with an image built from this branch, confirm it actually took:

```bash
docker exec gean_0 grep -c jemalloc /proc/1/maps    # must be > 0
docker exec gean_0 sh -c "awk '/\[heap\]/{f=1} f&&/^Rss:/{print \$2; exit}' /proc/1/smaps"   # expect 0
```

If the first is 0, the preload didn't load and the memory result will not reproduce.
