### PR TITLE
fix(docker): enable Haswell targeting with legacy builders

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,10 @@ WORKDIR /app
 # Copy Rust FFI dependencies first for better caching
 COPY xmss/rust/ xmss/rust/
 
-# Build Rust FFI libraries
-# On amd64: -Ctarget-cpu=haswell enables AVX2 SIMD in leanMultisig's backend
-# for ~6x prover speedup. Haswell (2013+) is the portable x86 baseline.
-# On arm64: build without x86 flags; native NEON is used automatically.
-ARG TARGETARCH
+# Detect the build-stage architecture: legacy builders do not populate TARGETARCH.
+# Match make ffi's Haswell/AVX2 baseline on x86_64; leave arm64 flags unchanged.
 RUN cd xmss/rust && \
-    if [ "$TARGETARCH" = "amd64" ]; then \
+    if [ "$(uname -m)" = "x86_64" ]; then \
       CARGO_ENCODED_RUSTFLAGS="-Ctarget-cpu=haswell" cargo build --profile multisig-release --locked; \
     else \
       cargo build --profile multisig-release --locked; \


### PR DESCRIPTION
## Description

Legacy Docker builders leave the automatic `TARGETARCH` argument unset, so the Rust FFI build silently skipped `-Ctarget-cpu=haswell` on x86_64. Detect the build-stage architecture with `uname -m`, matching `make ffi`, so those builds receive the intended Haswell/AVX2 target. Remove the unused argument and the unverified speedup claim from the comment.

Disassembly of the deployed baseline found no YMM instructions in either inspected Poseidon permutation implementation. The rebuilt and deployed fix contains AVX2 integer arithmetic, with 800–825 YMM instruction lines per implementation.

## Associated Issue

Related to #433: addresses the build configuration behind the per-proof performance investigation. The broader aggregation scheduling issue remains open.

## Test Plan

- Executed the original and patched Docker shell blocks in a temporary regression harness. Reproduced the missing flag on x86_64 with `TARGETARCH` unset; verified the fix with it unset or `amd64`. Simulated aarch64 with it unset or `arm64` receives no x86 flag.
- `make test`, `go vet ./...`, and `git diff --check` passed.
- Full local Docker build and network-disabled `--help` smoke check passed. Inspected exact Poseidon symbol ranges for AVX2 arithmetic.
- Deployed image verified on all four Gean nodes. In the initial 15-node devnet check, all clients reported head 102, justified 97, finalized 85, and synced; no restarts or errors were found in the sampled checks.
- Reviewed the committed diff against current `main` with the lean-review workflow; no further findings.

Early timing observation: `gean_0` raw-only proofs with 10 signatures at slots 24–86 averaged 4.53 s in the saved baseline (16 samples) and 1.56 s after the fix (24 samples). This is not a controlled speedup benchmark: host load and Lantern's revision differed, and the new run was short. Actual arm64/QEMU builds and sustained-run validation remain untested.

## Checklist

- [x] Repository guidelines reviewed (`CONTRIBUTING.md` is not present)
- [x] Self-review completed
- [ ] Permanent regression tests added (temporary shell regression harness and binary inspection used for this Dockerfile-only change)
- [x] Existing unit tests pass locally
